### PR TITLE
Show content under footer on small screen

### DIFF
--- a/src/Detail.tsx
+++ b/src/Detail.tsx
@@ -1,7 +1,7 @@
 import { Skeleton } from "primereact/skeleton";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { Annotation } from "./components/Annotations/annotation";
+import { Annotation } from "./components/Annotations/Annotation.tsx";
 import { Footer } from "./components/Footer/Footer";
 import { Mirador } from "./components/Mirador/Mirador";
 import { NOTES_VIEW } from "./components/Text/Annotated/MarkerTooltip.tsx";

--- a/src/components/Annotations/Annotation.tsx
+++ b/src/components/Annotations/Annotation.tsx
@@ -39,13 +39,13 @@ export function Annotation(props: AnnotationProps) {
             </Tab>
           )}
         </TabList>
-        <TabPanel id="metadata" className="text-brand1-800 h-full p-5">
+        <TabPanel id="metadata" className="text-brand1-800 h-full">
           {annotations.length > 0 && !props.isLoading ? (
             <projectConfig.components.MetadataPanel annotations={annotations} />
           ) : null}
         </TabPanel>
         {projectConfig.showWebAnnoTab && (
-          <TabPanel id="webannos" className="text-brand1-800 p-5">
+          <TabPanel id="webannos" className="text-brand1-800">
             <>
               <div className="flex">
                 <AnnotationFilter />

--- a/src/components/Text/TextPanel.tsx
+++ b/src/components/Text/TextPanel.tsx
@@ -39,7 +39,7 @@ export const TextPanel = (props: TextPanelProps) => {
         </button>
       </div>
 
-      <div className="mx-auto flex max-w-3xl pb-8">
+      <div className="mx-auto flex max-w-3xl" role="textpanel">
         {projectConfig.showAnnotations ? (
           <AnnotatedText text={props.text} showDetail={false} />
         ) : (

--- a/src/index.css
+++ b/src/index.css
@@ -382,3 +382,9 @@ input:valid + span::after {
     }
   }
 }
+
+/* Prevent footer from hiding tabpanel or textpanel content */
+div[role="tabpanel"] > *:last-child,
+div[role="textpanel"] > *:last-child {
+  padding-bottom: 5em;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -383,7 +383,7 @@ input:valid + span::after {
   }
 }
 
-/* Prevent footer from hiding tabpanel or textpanel content */
+/* Prevent footer from hiding TabPanel or TextPanel content */
 div[role="tabpanel"] > *:last-child,
 div[role="textpanel"] > *:last-child {
   margin-bottom: 5em;

--- a/src/index.css
+++ b/src/index.css
@@ -386,5 +386,5 @@ input:valid + span::after {
 /* Prevent footer from hiding tabpanel or textpanel content */
 div[role="tabpanel"] > *:last-child,
 div[role="textpanel"] > *:last-child {
-  padding-bottom: 5em;
+  margin-bottom: 5em;
 }


### PR DESCRIPTION
Fix content of text panels and tab panels hidden by the footer on small windows (see screenshot).
![image](https://github.com/user-attachments/assets/5f3ac42e-b0d3-4831-99dd-c037ae721265)

After fix:
![image](https://github.com/user-attachments/assets/226aceec-a53f-4433-8896-2670383a50d2)

