### PR TITLE
Disable responsive design by setting minimum device width of 1500px

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=1500, initial-scale=1.0" />
     <meta charset="UTF-8" />
     <title>%VITE_TITLE%</title>
     <link rel="icon" type="image/png" href="/src/assets/favicon.png" />


### PR DESCRIPTION
When opening textannoviz on a mobile phone, only the intro text (or placeholder) is shown. 
To allow users to search with textannoviz on their smartphones, this PR sets the viewport (min) width to `1500` pixels giving users access to textannoviz in the 'desktop' landscape layout.
More elegant solutions exist: we probably want a responsive mobile design that shows the search form and other crucial panes. However, what would be a good format? This requires some brainstorming and designing, @Doppen, @svandaalen ?
