### PR TITLE
Fix missing query facets

### DIFF
--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -290,6 +290,7 @@ export const Search = () => {
       <SearchForm
         onSearch={handleNewSearch}
         keywordFacets={keywordFacets}
+        searchQuery={searchQuery}
         updateAggs={updateAggs}
       />
       <SearchResultsColumn>

--- a/src/components/Search/SearchForm.tsx
+++ b/src/components/Search/SearchForm.tsx
@@ -28,6 +28,7 @@ import { removeTerm } from "./util/removeTerm.ts";
 interface SearchFormProps {
   onSearch: () => void;
   keywordFacets: FacetEntry[];
+  searchQuery: SearchQuery;
   updateAggs: (query: SearchQuery) => void;
 }
 
@@ -65,11 +66,13 @@ export function SearchForm(props: SearchFormProps) {
   React.useEffect(() => {
     if (defaultAggsIsInit) return;
     if (!isEmpty(props.keywordFacets)) {
+      const searchQueryTerms = Object.keys(props.searchQuery.terms);
+      const defaultKeywordAggs = projectConfig.defaultKeywordAggsToRender;
+      const relevantFacetNames = [...defaultKeywordAggs, ...searchQueryTerms];
+
       const initialFilteredAggs = props.keywordFacets.reduce<string[]>(
         (accumulator, keywordFacet) => {
-          if (
-            projectConfig.defaultKeywordAggsToRender.includes(keywordFacet[0])
-          ) {
+          if (relevantFacetNames.includes(keywordFacet[0])) {
             accumulator.push(keywordFacet[0]);
           }
           return accumulator;

--- a/src/components/Search/SearchForm.tsx
+++ b/src/components/Search/SearchForm.tsx
@@ -331,11 +331,8 @@ export function SearchForm(props: SearchFormProps) {
           )?.[1];
 
           return facetValue ? (
-            <>
-              <div
-                key={index}
-                className="max-h-[500px] w-full max-w-[450px] overflow-y-auto overflow-x-hidden"
-              >
+            <div key={`${index}-${facetName}`}>
+              <div className="max-h-[500px] w-full max-w-[450px] overflow-y-auto overflow-x-hidden">
                 <KeywordFacet
                   facetName={facetName}
                   facet={facetValue}
@@ -362,7 +359,7 @@ export function SearchForm(props: SearchFormProps) {
                   )}
                 </div>
               )}
-            </>
+            </div>
           ) : null;
         })}
     </div>

--- a/src/projects/republic/config/index.tsx
+++ b/src/projects/republic/config/index.tsx
@@ -16,8 +16,8 @@ import { englishRepublicLabels } from "./englishRepublicLabels.ts";
 
 export const republicConfig: ProjectConfig = merge({}, defaultConfig, {
   id: "republic",
-  // broccoliUrl: "https://broccoli.tt.di.huc.knaw.nl",
-  broccoliUrl: "https://broccoli.republic-caf.diginfra.org",
+  broccoliUrl: "https://broccoli.tt.di.huc.knaw.nl",
+  // broccoliUrl: "https://broccoli.republic-caf.diginfra.org",
   colours: {
     resolution: "yellow",
     attendant: "#DB4437",


### PR DESCRIPTION
When opening the search page with an query in the url, non-default facets are not rendered.
This PR fixes the `filteredAggs` of `SearchForm`: this facet list now also includes the facets mentioned in the current `searchQuery.terms` . When you open a search page, any search facets of an existing query will also be rendered in the search form. 

This PR depends on https://github.com/knaw-huc/textannoviz/pull/205