### PR TITLE
Store search history in local storage, no refactoring

### DIFF
--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -47,7 +47,7 @@ export const Search = () => {
     searchQuery,
     setSearchQuery,
     setSearchResults,
-    updateSearchQueryHistory,
+    addSearchQuery,
     toFirstPage,
     searchFacetTypes,
     setSearchFacetTypes,
@@ -230,7 +230,7 @@ export const Search = () => {
 
       setShowingResults(true);
 
-      updateSearchQueryHistory(searchQuery);
+      addSearchQuery(searchQuery);
       setSelectedFacets(searchQuery);
 
       const searchResults = await getSearchResults(

--- a/src/components/Search/SearchForm.tsx
+++ b/src/components/Search/SearchForm.tsx
@@ -39,7 +39,6 @@ const searchFormClasses =
 export function SearchForm(props: SearchFormProps) {
   const { onSearch } = props;
   const projectConfig = useProjectStore(projectConfigSelector);
-  const queryHistory = useSearchStore((state) => state.searchQueryHistory);
   const [isFromDateValid, setIsFromDateValid] = React.useState(true);
   const [isToDateValid, setIsToDateValid] = React.useState(true);
   const [showMoreClicked, setShowMoreClicked] =
@@ -273,10 +272,8 @@ export function SearchForm(props: SearchFormProps) {
       {projectConfig.showSearchQueryHistory && (
         <div className="w-full max-w-[450px]">
           <SearchQueryHistory
-            queryHistory={queryHistory}
             goToQuery={goToQuery}
             projectConfig={projectConfig}
-            disabled={!queryHistory.length}
           />
         </div>
       )}

--- a/src/components/Search/SearchQueryHistory.tsx
+++ b/src/components/Search/SearchQueryHistory.tsx
@@ -101,11 +101,19 @@ export const SearchQueryHistory = (props: SearchQueryHistoryProps) => {
  */
 function formatQueryDate(timestamp: number): string {
   const date = new Date(timestamp);
-  const time = `${date.getHours()}:${date.getMinutes()}`;
+
+  const time = `${doubleDigit(date.getHours())}:${doubleDigit(
+    date.getMinutes(),
+  )}`;
+
   if (isToday(date)) {
     return time;
   }
   return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()} ${time}`;
+
+  function doubleDigit(n: number) {
+    return n.toString().padStart(2, "0");
+  }
 
   function isToday(toTest: Date) {
     const today = new Date();

--- a/src/components/Search/SearchQueryHistory.tsx
+++ b/src/components/Search/SearchQueryHistory.tsx
@@ -7,9 +7,10 @@ import {
   useProjectStore,
 } from "../../stores/project.ts";
 import { SearchQuery } from "../../stores/search/search-query-slice.ts";
+import { DatedSearchQuery } from "../../stores/search/search-history-slice.ts";
 
 type SearchQueryHistoryProps = {
-  queryHistory: SearchQuery[];
+  queryHistory: DatedSearchQuery[];
   goToQuery: (query: SearchQuery) => void;
   projectConfig: ProjectConfig;
   disabled: boolean;
@@ -39,45 +40,50 @@ export const SearchQueryHistory = (props: SearchQueryHistoryProps) => {
       {isOpen && (
         <ol className="ml-6 mt-4 list-decimal">
           {lastQueries.length ? (
-            lastQueries.map((query, index) => (
-              <li
-                key={index}
-                onClick={() => props.goToQuery(query)}
-                className="mb-4 cursor-pointer hover:underline"
-              >
-                {query.fullText && (
-                  <div>
-                    <strong>{translate("TEXT")}: </strong> {query.fullText}
-                  </div>
-                )}
-                {query.dateFacet && (
-                  <>
+            lastQueries.map((entry, index) => {
+              const query = entry.query;
+              return (
+                <li
+                  key={index}
+                  onClick={() => props.goToQuery(query)}
+                  className="mb-4 cursor-pointer hover:underline"
+                >
+                  {query.fullText && (
                     <div>
-                      <strong>{translate("DATE_FROM")}: </strong>{" "}
-                      {query.dateFrom}
-                    </div>{" "}
-                    <div>
-                      <strong>{translate("UP_TO_AND_INCLUDING")}: </strong>{" "}
-                      {query.dateTo}
+                      <strong>{translate("TEXT")}: </strong> {query.fullText}
                     </div>
-                  </>
-                )}
-                {query.terms && (
-                  <div>
-                    {Object.keys(query.terms).length > 0 ? (
-                      <strong>{translate("SELECTED_FACETS")}:</strong>
-                    ) : null}
-                    {Object.entries(query.terms).map(([key, value], index) => (
-                      <div key={index}>
-                        {`${translateProject(key)}: ${translateProject(
-                          value[0],
-                        )}`}
+                  )}
+                  {query.dateFacet && (
+                    <>
+                      <div>
+                        <strong>{translate("DATE_FROM")}: </strong>{" "}
+                        {query.dateFrom}
+                      </div>{" "}
+                      <div>
+                        <strong>{translate("UP_TO_AND_INCLUDING")}: </strong>{" "}
+                        {query.dateTo}
                       </div>
-                    ))}
-                  </div>
-                )}
-              </li>
-            ))
+                    </>
+                  )}
+                  {query.terms && (
+                    <div>
+                      {Object.keys(query.terms).length > 0 ? (
+                        <strong>{translate("SELECTED_FACETS")}:</strong>
+                      ) : null}
+                      {Object.entries(query.terms).map(
+                        ([key, value], index) => (
+                          <div key={index}>
+                            {`${translateProject(key)}: ${translateProject(
+                              value[0],
+                            )}`}
+                          </div>
+                        ),
+                      )}
+                    </div>
+                  )}
+                </li>
+              );
+            })
           ) : (
             <div>{translate("NO_SEARCH_HISTORY")}.</div>
           )}

--- a/src/components/Search/SearchQueryHistory.tsx
+++ b/src/components/Search/SearchQueryHistory.tsx
@@ -38,7 +38,7 @@ export const SearchQueryHistory = (props: SearchQueryHistoryProps) => {
         {translate("SEARCH_HISTORY")}
       </Button>
       {isOpen && (
-        <ol className="ml-6 mt-4 list-decimal">
+        <ul className="list ml-6 mt-4">
           {lastQueries.length ? (
             lastQueries.map((entry, index) => {
               const query = entry.query;
@@ -48,6 +48,9 @@ export const SearchQueryHistory = (props: SearchQueryHistoryProps) => {
                   onClick={() => props.goToQuery(query)}
                   className="mb-4 cursor-pointer hover:underline"
                 >
+                  <span className="query-date">
+                    {formatQueryDate(entry.date)}
+                  </span>
                   {query.fullText && (
                     <div>
                       <strong>{translate("TEXT")}: </strong> {query.fullText}
@@ -87,8 +90,29 @@ export const SearchQueryHistory = (props: SearchQueryHistoryProps) => {
           ) : (
             <div>{translate("NO_SEARCH_HISTORY")}.</div>
           )}
-        </ol>
+        </ul>
       )}
     </>
   );
 };
+
+/**
+ * TODO: Wait for temporal, or introduce moment?
+ */
+function formatQueryDate(timestamp: number): string {
+  const date = new Date(timestamp);
+  const time = `${date.getHours()}:${date.getMinutes()}`;
+  if (isToday(date)) {
+    return time;
+  }
+  return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()} ${time}`;
+
+  function isToday(toTest: Date) {
+    const today = new Date();
+    return (
+      toTest.getDate() === today.getDate() &&
+      toTest.getMonth() === today.getMonth() &&
+      toTest.getFullYear() === today.getFullYear()
+    );
+  }
+}

--- a/src/components/Search/SearchQueryHistory.tsx
+++ b/src/components/Search/SearchQueryHistory.tsx
@@ -7,24 +7,23 @@ import {
   useProjectStore,
 } from "../../stores/project.ts";
 import { SearchQuery } from "../../stores/search/search-query-slice.ts";
-import { DatedSearchQuery } from "../../stores/search/search-history-slice.ts";
+import { useSearchStore } from "../../stores/search/search-store.ts";
 
 type SearchQueryHistoryProps = {
-  queryHistory: DatedSearchQuery[];
   goToQuery: (query: SearchQuery) => void;
   projectConfig: ProjectConfig;
-  disabled: boolean;
 };
 
 const MAX_DISPLAY = 10;
 
 export const SearchQueryHistory = (props: SearchQueryHistoryProps) => {
+  const { searchQueryHistory, removeSearchQuery } = useSearchStore();
   const translate = useProjectStore(translateSelector);
   const translateProject = useProjectStore(translateProjectSelector);
   const [isOpen, setOpen] = useState(false);
 
-  const moreThanDisplayable = props.queryHistory.length >= MAX_DISPLAY;
-  const lastQueries = props.queryHistory
+  const moreThanDisplayable = searchQueryHistory.length >= MAX_DISPLAY;
+  const lastQueries = searchQueryHistory
     .slice(moreThanDisplayable ? -MAX_DISPLAY : 0)
     .reverse();
 
@@ -33,7 +32,7 @@ export const SearchQueryHistory = (props: SearchQueryHistoryProps) => {
       <Button
         onPress={() => setOpen(!isOpen)}
         className="bg-brand2-100 text-brand2-700 hover:text-brand2-900 disabled:bg-brand2-50 active:bg-brand2-200 disabled:text-brand2-200 rounded px-2 py-2 text-sm outline-none"
-        isDisabled={props.disabled}
+        isDisabled={!searchQueryHistory.length}
       >
         {translate("SEARCH_HISTORY")}
       </Button>
@@ -43,47 +42,54 @@ export const SearchQueryHistory = (props: SearchQueryHistoryProps) => {
             lastQueries.map((entry, index) => {
               const query = entry.query;
               return (
-                <li
-                  key={index}
-                  onClick={() => props.goToQuery(query)}
-                  className="mb-4 cursor-pointer hover:underline"
-                >
+                <li key={index} className="mb-4">
                   <span className="query-date">
                     {formatQueryDate(entry.date)}
                   </span>
-                  {query.fullText && (
-                    <div>
-                      <strong>{translate("TEXT")}: </strong> {query.fullText}
-                    </div>
-                  )}
-                  {query.dateFacet && (
-                    <>
+                  <span
+                    className="query-delete"
+                    onClick={() => removeSearchQuery(entry.date)}
+                  >
+                    [x]
+                  </span>
+                  <div
+                    onClick={() => props.goToQuery(query)}
+                    className="search-query cursor-pointer hover:underline"
+                  >
+                    {query.fullText && (
                       <div>
-                        <strong>{translate("DATE_FROM")}: </strong>{" "}
-                        {query.dateFrom}
-                      </div>{" "}
-                      <div>
-                        <strong>{translate("UP_TO_AND_INCLUDING")}: </strong>{" "}
-                        {query.dateTo}
+                        <strong>{translate("TEXT")}: </strong> {query.fullText}
                       </div>
-                    </>
-                  )}
-                  {query.terms && (
-                    <div>
-                      {Object.keys(query.terms).length > 0 ? (
-                        <strong>{translate("SELECTED_FACETS")}:</strong>
-                      ) : null}
-                      {Object.entries(query.terms).map(
-                        ([key, value], index) => (
-                          <div key={index}>
-                            {`${translateProject(key)}: ${translateProject(
-                              value[0],
-                            )}`}
-                          </div>
-                        ),
-                      )}
-                    </div>
-                  )}
+                    )}
+                    {query.dateFacet && (
+                      <>
+                        <div>
+                          <strong>{translate("DATE_FROM")}: </strong>{" "}
+                          {query.dateFrom}
+                        </div>{" "}
+                        <div>
+                          <strong>{translate("UP_TO_AND_INCLUDING")}: </strong>{" "}
+                          {query.dateTo}
+                        </div>
+                      </>
+                    )}
+                    {query.terms && (
+                      <div>
+                        {Object.keys(query.terms).length > 0 ? (
+                          <strong>{translate("SELECTED_FACETS")}:</strong>
+                        ) : null}
+                        {Object.entries(query.terms).map(
+                          ([key, value], index) => (
+                            <div key={index}>
+                              {`${translateProject(key)}: ${translateProject(
+                                value[0],
+                              )}`}
+                            </div>
+                          ),
+                        )}
+                      </div>
+                    )}
+                  </div>
                 </li>
               );
             })
@@ -109,11 +115,9 @@ function formatQueryDate(timestamp: number): string {
   if (isToday(date)) {
     return time;
   }
-  return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()} ${time}`;
-
-  function doubleDigit(n: number) {
-    return n.toString().padStart(2, "0");
-  }
+  return `${date.getFullYear()}-${
+    date.getMonth() + 1
+  }-${date.getDate()} ${time}`;
 
   function isToday(toTest: Date) {
     const today = new Date();
@@ -122,5 +126,9 @@ function formatQueryDate(timestamp: number): string {
       toTest.getMonth() === today.getMonth() &&
       toTest.getFullYear() === today.getFullYear()
     );
+  }
+
+  function doubleDigit(n: number) {
+    return n.toString().padStart(2, "0");
   }
 }

--- a/src/components/Search/SearchQueryHistory.tsx
+++ b/src/components/Search/SearchQueryHistory.tsx
@@ -108,16 +108,17 @@ export const SearchQueryHistory = (props: SearchQueryHistoryProps) => {
 function formatQueryDate(timestamp: number): string {
   const date = new Date(timestamp);
 
-  const time = `${doubleDigit(date.getHours())}:${doubleDigit(
-    date.getMinutes(),
-  )}`;
+  const HH = doubleDigit(date.getHours());
+  const mm = doubleDigit(date.getMinutes());
+  const time = `${HH}:${mm}`;
 
   if (isToday(date)) {
     return time;
   }
-  return `${date.getFullYear()}-${
-    date.getMonth() + 1
-  }-${date.getDate()} ${time}`;
+  const YYYY = date.getFullYear();
+  const MM = date.getMonth() + 1;
+  const DD = date.getDate();
+  return `${YYYY}-${MM}-${DD} ${time}`;
 
   function isToday(toTest: Date) {
     const today = new Date();

--- a/src/components/Search/SearchResults.tsx
+++ b/src/components/Search/SearchResults.tsx
@@ -142,7 +142,7 @@ export function SearchResults(props: SearchResultsProps) {
 
   function returnToPrevDateRange() {
     if (queryHistory.length < 2) return;
-    const prevQuery = queryHistory[queryHistory.length - 2];
+    const prevQuery = queryHistory[queryHistory.length - 2].query;
 
     setHistogramZoomed(false);
 

--- a/src/index.css
+++ b/src/index.css
@@ -389,13 +389,13 @@ div[role="textpanel"] > *:last-child {
   padding-bottom: 5em;
 }
 
+.query-delete,
 .query-date {
   font-size: 0.9em;
   color: #ccc;
 }
 
 .query-delete {
-  color: #ccc;
   float: right;
   &:hover {
     text-decoration: underline;

--- a/src/index.css
+++ b/src/index.css
@@ -388,3 +388,8 @@ div[role="tabpanel"] > *:last-child,
 div[role="textpanel"] > *:last-child {
   padding-bottom: 5em;
 }
+
+.query-date {
+  font-size: small;
+  color: #ccc;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -390,6 +390,16 @@ div[role="textpanel"] > *:last-child {
 }
 
 .query-date {
-  font-size: small;
+  font-size: 0.9em;
   color: #ccc;
+}
+
+.query-delete {
+  color: #ccc;
+  float: right;
+  &:hover {
+    text-decoration: underline;
+    color: black;
+    cursor: pointer;
+  }
 }

--- a/src/projects/republic/config/index.tsx
+++ b/src/projects/republic/config/index.tsx
@@ -16,8 +16,8 @@ import { englishRepublicLabels } from "./englishRepublicLabels.ts";
 
 export const republicConfig: ProjectConfig = merge({}, defaultConfig, {
   id: "republic",
-  broccoliUrl: "https://broccoli.tt.di.huc.knaw.nl",
-  // broccoliUrl: "https://broccoli.republic-caf.diginfra.org",
+  // broccoliUrl: "https://broccoli.tt.di.huc.knaw.nl",
+  broccoliUrl: "https://broccoli.republic-caf.diginfra.org",
   colours: {
     resolution: "yellow",
     attendant: "#DB4437",

--- a/src/projects/republic/config/index.tsx
+++ b/src/projects/republic/config/index.tsx
@@ -16,8 +16,8 @@ import { englishRepublicLabels } from "./englishRepublicLabels.ts";
 
 export const republicConfig: ProjectConfig = merge({}, defaultConfig, {
   id: "republic",
-  // broccoliUrl: "https://broccoli.tt.di.huc.knaw.nl",
-  broccoliUrl: "https://broccoli.republic-caf.diginfra.org",
+  broccoliUrl: "https://broccoli.tt.di.huc.knaw.nl",
+  // broccoliUrl: "https://broccoli.republic-caf.diginfra.org",
   colours: {
     resolution: "yellow",
     attendant: "#DB4437",

--- a/src/stores/search/search-history-slice.ts
+++ b/src/stores/search/search-history-slice.ts
@@ -1,0 +1,36 @@
+import { StateCreator } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import { SearchQuery } from "./search-query-slice.ts";
+
+type Timestamp = number;
+export type DatedSearchQuery = {
+  date: Timestamp;
+  query: SearchQuery;
+};
+
+export type SearchHistorySlice = {
+  searchQueryHistory: DatedSearchQuery[];
+  updateSearchQueryHistory: (update: SearchQuery) => void;
+};
+
+export const createSearchHistorySlice: StateCreator<
+  SearchHistorySlice,
+  [],
+  [["zustand/persist", unknown]],
+  SearchHistorySlice
+> = persist(
+  (set) => ({
+    searchQueryHistory: [],
+    updateSearchQueryHistory: (update: SearchQuery) => {
+      const datedQuery: DatedSearchQuery = { date: Date.now(), query: update };
+      return set((prev) => ({
+        ...prev,
+        searchQueryHistory: [...prev.searchQueryHistory, datedQuery],
+      }));
+    },
+  }),
+  {
+    name: "search-history",
+    storage: createJSONStorage(() => localStorage),
+  },
+);

--- a/src/stores/search/search-history-slice.ts
+++ b/src/stores/search/search-history-slice.ts
@@ -2,7 +2,7 @@ import { StateCreator } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { SearchQuery } from "./search-query-slice.ts";
 
-type Timestamp = number;
+export type Timestamp = number;
 export type DatedSearchQuery = {
   date: Timestamp;
   query: SearchQuery;
@@ -10,7 +10,8 @@ export type DatedSearchQuery = {
 
 export type SearchHistorySlice = {
   searchQueryHistory: DatedSearchQuery[];
-  updateSearchQueryHistory: (update: SearchQuery) => void;
+  addSearchQuery: (update: SearchQuery) => void;
+  removeSearchQuery: (toDelete: Timestamp) => void;
 };
 
 export const createSearchHistorySlice: StateCreator<
@@ -21,12 +22,23 @@ export const createSearchHistorySlice: StateCreator<
 > = persist(
   (set) => ({
     searchQueryHistory: [],
-    updateSearchQueryHistory: (update: SearchQuery) => {
+    addSearchQuery: (update: SearchQuery) => {
       const datedQuery: DatedSearchQuery = { date: Date.now(), query: update };
       return set((prev) => ({
         ...prev,
         searchQueryHistory: [...prev.searchQueryHistory, datedQuery],
       }));
+    },
+    removeSearchQuery: (toRemove: Timestamp) => {
+      return set((prev) => {
+        const update = prev.searchQueryHistory.filter(
+          (entry) => entry.date !== toRemove,
+        );
+        return {
+          ...prev,
+          searchQueryHistory: update,
+        };
+      });
     },
   }),
   {

--- a/src/stores/search/search-history-slice.ts
+++ b/src/stores/search/search-history-slice.ts
@@ -1,6 +1,7 @@
 import { StateCreator } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { SearchQuery } from "./search-query-slice.ts";
+import _ from "lodash";
 
 export type Timestamp = number;
 export type DatedSearchQuery = {
@@ -23,11 +24,27 @@ export const createSearchHistorySlice: StateCreator<
   (set) => ({
     searchQueryHistory: [],
     addSearchQuery: (update: SearchQuery) => {
-      const datedQuery: DatedSearchQuery = { date: Date.now(), query: update };
-      return set((prev) => ({
-        ...prev,
-        searchQueryHistory: [...prev.searchQueryHistory, datedQuery],
-      }));
+      return set((prev) => {
+        if (
+          prev.searchQueryHistory.find((entry) =>
+            _.isEqual(entry.query, update),
+          )
+        ) {
+          console.debug("query already exists in history", {
+            query: update,
+            history: prev.searchQueryHistory,
+          });
+          return prev;
+        }
+        const datedQuery: DatedSearchQuery = {
+          date: Date.now(),
+          query: update,
+        };
+        return {
+          ...prev,
+          searchQueryHistory: [...prev.searchQueryHistory, datedQuery],
+        };
+      });
     },
     removeSearchQuery: (toRemove: Timestamp) => {
       return set((prev) => {

--- a/src/stores/search/search-query-slice.ts
+++ b/src/stores/search/search-query-slice.ts
@@ -30,9 +30,7 @@ export type SearchQuery = {
 
 export type SearchQuerySlice = {
   searchQuery: SearchQuery;
-  searchQueryHistory: SearchQuery[];
   setSearchQuery: (update: SearchQuery) => void;
-  updateSearchQueryHistory: (update: SearchQuery) => void;
 };
 
 export const createSearchQuerySlice: StateCreator<
@@ -49,16 +47,10 @@ export const createSearchQuerySlice: StateCreator<
     fullText: "",
     terms: {},
   },
-  searchQueryHistory: [],
   setSearchQuery: (update) =>
     set((prev) => ({
       ...prev,
       searchQuery: update,
-    })),
-  updateSearchQueryHistory: (update: SearchQuery) =>
-    set((prev) => ({
-      ...prev,
-      searchQueryHistory: [...prev.searchQueryHistory, update],
     })),
 });
 

--- a/src/stores/search/search-store.ts
+++ b/src/stores/search/search-store.ts
@@ -15,15 +15,21 @@ import {
   createSearchFacetTypesSlice,
   SearchFacetTypesSlice,
 } from "./search-facet-types-slice.ts";
+import {
+  createSearchHistorySlice,
+  SearchHistorySlice,
+} from "./search-history-slice.ts";
 
 export type SearchStore = SearchResultsSlice &
   SearchParamsSlice &
   SearchQuerySlice &
-  SearchFacetTypesSlice;
+  SearchFacetTypesSlice &
+  SearchHistorySlice;
 
 export const useSearchStore = create<SearchStore>()((...a) => ({
   ...createSearchFacetTypesSlice(...a),
   ...createSearchResultsSlice(...a),
   ...createSearchParamsSlice(...a),
   ...createSearchQuerySlice(...a),
+  ...createSearchHistorySlice(...a),
 }));


### PR DESCRIPTION
Store search history in localStorage

Also:
- show creation date-time, 
- allow deleting entries from history
- skip duplicate queries

Copies and cherry-picks functionality from https://github.com/knaw-huc/textannoviz/tree/local-search-history