### PR TITLE
(Temporarily) disable English for Republic, only show Dutch labels

### DIFF
--- a/src/projects/republic/config/index.tsx
+++ b/src/projects/republic/config/index.tsx
@@ -12,7 +12,6 @@ import { AnnotationButtons } from "../AnnotationButtons.tsx";
 import { MetadataPanel } from "../MetadataPanel.tsx";
 import { SearchItem } from "../SearchItem.tsx";
 import { dutchRepublicLabels } from "./dutchRepublicLabels.ts";
-import { englishRepublicLabels } from "./englishRepublicLabels.ts";
 
 export const republicConfig: ProjectConfig = merge({}, defaultConfig, {
   id: "republic",
@@ -90,7 +89,7 @@ export const republicConfig: ProjectConfig = merge({}, defaultConfig, {
   selectedLanguage: "nl",
   languages: [
     { code: "nl", labels: dutchRepublicLabels },
-    { code: "en", labels: englishRepublicLabels },
+    // { code: "en", labels: englishRepublicLabels },
   ],
   mirador: {
     showTopMenuButton: true,


### PR DESCRIPTION
This PR resolves #221.