### PR TITLE
Reinstate defaultAggsIsInit removed in issues/208

### DIFF
--- a/src/components/Search/SearchForm.tsx
+++ b/src/components/Search/SearchForm.tsx
@@ -45,6 +45,7 @@ export function SearchForm(props: SearchFormProps) {
   const [showMoreClicked, setShowMoreClicked] =
     React.useState<ShowMoreClickedState>({});
   const [filteredAggs, setFilteredAggs] = React.useState<string[]>([]);
+  const [defaultAggsIsInit, setDefaultAggsIsInit] = React.useState(false);
 
   const {
     searchUrlParams,
@@ -62,6 +63,8 @@ export function SearchForm(props: SearchFormProps) {
   );
 
   React.useEffect(() => {
+    if (defaultAggsIsInit) return;
+
     if (!isEmpty(props.keywordFacets)) {
       const searchQueryTerms = Object.keys(props.searchQuery.terms);
       const defaultKeywordAggs = projectConfig.defaultKeywordAggsToRender;
@@ -77,6 +80,7 @@ export function SearchForm(props: SearchFormProps) {
         [],
       );
       setFilteredAggs(initialFilteredAggs);
+      setDefaultAggsIsInit(true);
     }
   }, [props.keywordFacets, projectConfig.defaultKeywordAggsToRender]);
 


### PR DESCRIPTION
Fix:
_wanneer je een extra facet aanzet via filter facetten en dan een facetitem uit een ander facet aanvinkt, de getoonde facetten dan weer resetten naar default. Je kunt dit reproduceren door bv. Attendants-ID aan te zetten en dan te zoeken op Propositietype missive. Wanneer de zoekresultaten er zijn, is Attendants-ID verdwenen uit de facettenlijst._