### PR TITLE
Remove old, deprecated RAA link from attedants in Republic metadata panel

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -1,3 +1,0 @@
-export const HOSTS = {
-  RAA: "https://switch.sd.di.huc.knaw.nl/raa/persoon",
-};

--- a/src/projects/republic/MetadataPanel.tsx
+++ b/src/projects/republic/MetadataPanel.tsx
@@ -1,7 +1,6 @@
 import { UserIcon } from "@heroicons/react/24/solid";
 import React from "react";
 import { useParams } from "react-router-dom";
-import { HOSTS } from "../../Config";
 import {
   AnnoRepoAnnotation,
   AttendanceListBody,
@@ -114,19 +113,7 @@ function AttendantsMetadata(props: { annotations: AnnoRepoAnnotation[] }) {
                 className="flex flex-row items-center justify-start gap-1 py-1 text-sm"
               >
                 <UserIcon className="inline h-3 w-3" />
-                <a
-                  title="Link"
-                  rel="noreferrer"
-                  target="_blank"
-                  href={
-                    attendant.delegateId > 0
-                      ? `${HOSTS.RAA}/${attendant.delegateId}`
-                      : undefined
-                  }
-                  className="hover:text-brand1-900 text-inherit no-underline hover:underline"
-                >
-                  {attendant.delegateName}
-                </a>
+                {attendant.delegateName}
               </li>
             ) : null,
         )}


### PR DESCRIPTION
Resolves #231.