### PR TITLE
Infinite spinner

### DIFF
--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -170,26 +170,26 @@ export const Search = () => {
     setSelectedFacets(newSearchQuery);
 
     if (isSearchableQuery(queryDecoded, defaultSearchQuery)) {
-      setIsLoading(true);
       doSearch();
     } else {
       setUrlParamsAndSearchResultsInit(true);
     }
 
     async function doSearch() {
+      setIsLoading(true);
       const searchResults = await getSearchResults(
         searchFacetTypes,
         searchUrlParams,
         newSearchQuery,
         aborter.signal,
       );
+      setIsLoading(false);
       if (searchResults) {
         setSearchResults(searchResults.results);
         setKeywordFacets(searchResults.facets);
       }
       setShowingResults(true);
       setUrlParamsAndSearchResultsInit(true);
-      setIsLoading(false);
     }
 
     return () => aborter.abort();
@@ -220,7 +220,6 @@ export const Search = () => {
   useEffect(() => {
     const aborter = new AbortController();
     if (isDirty) {
-      setIsLoading(true);
       searchWhenDirty();
     }
 
@@ -242,46 +241,44 @@ export const Search = () => {
       addToHistory(searchQuery);
       setSelectedFacets(searchQuery);
 
+      setIsLoading(true);
       const searchResults = await getSearchResults(
         searchFacetTypes,
         searchUrlParams,
         searchQuery,
         aborter.signal,
       );
+      setIsLoading(false);
       if (searchResults) {
         setSearchResults(searchResults.results);
         setKeywordFacets(searchResults.facets);
       }
       setDirty(false);
-      setIsLoading(false);
     }
 
     return () => aborter.abort();
   }, [isDirty, searchQuery]);
 
   async function updateAggs(query: SearchQuery) {
-    setIsLoading(true);
     const newParams = {
       ...searchUrlParams,
       indexName: projectConfig.elasticIndexName,
       size: 0,
     };
 
+    setIsLoading(true);
     const searchResults = await sendSearchQuery(
       projectConfig,
       newParams,
       toRequestBody(query),
     );
-
-    if (!searchResults) {
-      return;
-    }
-
     setIsLoading(false);
 
-    setKeywordFacets(
-      filterFacetsByType(searchFacetTypes, searchResults.aggs, "keyword"),
-    );
+    if (searchResults) {
+      setKeywordFacets(
+        filterFacetsByType(searchFacetTypes, searchResults.aggs, "keyword"),
+      );
+    }
   }
 
   function handleNewSearch() {

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -170,8 +170,8 @@ export const Search = () => {
     setSelectedFacets(newSearchQuery);
 
     if (isSearchableQuery(queryDecoded, defaultSearchQuery)) {
-      doSearch();
       setIsLoading(true);
+      doSearch();
     } else {
       setUrlParamsAndSearchResultsInit(true);
     }

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -192,7 +192,10 @@ export const Search = () => {
       setUrlParamsAndSearchResultsInit(true);
     }
 
-    return () => aborter.abort();
+    return () => {
+      setIsLoading(false);
+      aborter.abort();
+    };
   }, [urlParams, isInit, isUrlParamsAndSearchResultsInit]);
 
   //THIS ONE IS RUN MULTIPLE TIMES
@@ -256,7 +259,10 @@ export const Search = () => {
       setDirty(false);
     }
 
-    return () => aborter.abort();
+    return () => {
+      setIsLoading(false);
+      aborter.abort();
+    };
   }, [isDirty, searchQuery]);
 
   async function updateAggs(query: SearchQuery) {


### PR DESCRIPTION
Note: minimal fix would be bfbbdd834c315d656fc180828097a21cf13f58ac

But maybe we want to keep the isLoading indicators close to the actual request? See 79eb9b706d464005879ce5dea0bf549e08ab4c48 
This to prevent possible other bugs like the (removed) early return on this line https://github.com/knaw-huc/textannoviz/commit/79eb9b706d464005879ce5dea0bf549e08ab4c48#diff-b14badfc7934e0d190f67e18185c64775760842376819aba5f46400527b7ca06L276 ?