### PR TITLE
Fix default query being populated by non-default search query

### DIFF
--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -10,6 +10,7 @@ import {
   useProjectStore,
 } from "../../stores/project.ts";
 import {
+  blankSearchQuery,
   FacetEntry,
   filterFacetsByType,
   SearchQuery,
@@ -110,8 +111,7 @@ export const Search = () => {
         "keyword",
       );
       const defaultSearchQuery = {
-        ...searchQuery,
-        aggs: aggregations,
+        ...blankSearchQuery,
         dateFrom: projectConfig.initialDateFrom,
         dateTo: projectConfig.initialDateTo,
         rangeFrom: projectConfig.initialRangeFrom,
@@ -119,6 +119,7 @@ export const Search = () => {
       };
       const newSearchQuery: SearchQuery = {
         ...defaultSearchQuery,
+        aggs: aggregations,
         ...queryDecoded,
       };
 

--- a/src/stores/search/search-query-slice.ts
+++ b/src/stores/search/search-query-slice.ts
@@ -34,20 +34,22 @@ export type SearchQuerySlice = {
   setSearchQuery: (update: SearchQuery) => void;
 };
 
+export const blankSearchQuery = {
+  dateFrom: "",
+  dateTo: "",
+  rangeFrom: "",
+  rangeTo: "",
+  fullText: "",
+  terms: {},
+};
+
 export const createSearchQuerySlice: StateCreator<
   SearchQuerySlice,
   [],
   [],
   SearchQuerySlice
 > = (set) => ({
-  searchQuery: {
-    dateFrom: "",
-    dateTo: "",
-    rangeFrom: "",
-    rangeTo: "",
-    fullText: "",
-    terms: {},
-  },
+  searchQuery: blankSearchQuery,
   setSearchQuery: (update) =>
     set((prev) => ({
       ...prev,


### PR DESCRIPTION
Fix `defaultQuery`: `searchQuery` was already populated by the fullText, making the default query not default anymore