### PR TITLE
Fix missing spinning on existing query: set loading=false only when needed

### DIFF
--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -172,6 +172,10 @@ export const Search = () => {
 
     if (isSearchableQuery(queryDecoded, defaultSearchQuery)) {
       doSearch();
+      return () => {
+        setIsLoading(false);
+        aborter.abort();
+      };
     } else {
       setUrlParamsAndSearchResultsInit(true);
     }
@@ -192,11 +196,6 @@ export const Search = () => {
       setShowingResults(true);
       setUrlParamsAndSearchResultsInit(true);
     }
-
-    return () => {
-      setIsLoading(false);
-      aborter.abort();
-    };
   }, [urlParams, isInit, isUrlParamsAndSearchResultsInit]);
 
   //THIS ONE IS RUN MULTIPLE TIMES
@@ -222,10 +221,16 @@ export const Search = () => {
 
   // Run when user modifies search query or params:
   useEffect(() => {
-    const aborter = new AbortController();
-    if (isDirty) {
-      searchWhenDirty();
+    if (!isDirty) {
+      return;
     }
+
+    const aborter = new AbortController();
+    searchWhenDirty();
+    return () => {
+      setIsLoading(false);
+      aborter.abort();
+    };
 
     async function searchWhenDirty() {
       const isEmptySearch =
@@ -259,11 +264,6 @@ export const Search = () => {
       }
       setDirty(false);
     }
-
-    return () => {
-      setIsLoading(false);
-      aborter.abort();
-    };
   }, [isDirty, searchQuery]);
 
   async function updateAggs(query: SearchQuery) {


### PR DESCRIPTION
Fix missing spinner when entering page with existing query. Fixes https://github.com/knaw-huc/textannoviz/issues/284
The `doSearch` and `searchWhenDirty` useEffects always return a destructor that sets isLoading to false, also when the effect is not actually loading something. This results in a `searchWhenDirty` that sets isLoading to false multiple times, also when isDirty is false, and probably also at a moment when `doSearch` has set isLoading to true and is actually searching.
This PR fixes this by only returning the destructor when the useEffects results in a search.
