### PR TITLE
Show search results on home page

### DIFF
--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -119,9 +119,7 @@ export const Search = () => {
 
   const [isDefaultQuery, setIsDefaultQuery] = useState(false);
   useEffect(() => {
-    const result = _.isEqual(defaultQuery, searchQuery);
-    console.log("isDefaultQuery?", { result, defaultQuery, searchQuery });
-    setIsDefaultQuery(result);
+    setIsDefaultQuery(_.isEqual(defaultQuery, searchQuery));
   }, [defaultQuery, searchQuery, searchResults]);
 
   return (

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -126,10 +126,7 @@ export const Search = () => {
 
   return (
     <div>
-      <p>Is default? {`${isDefaultQuery}`}</p>
-
       {isLoading && <SearchLoadingSpinner />}
-
       <div
         id="searchContainer"
         className="mx-auto flex h-full w-full grow flex-row content-stretch items-stretch self-stretch"
@@ -142,7 +139,7 @@ export const Search = () => {
         />
         <SearchResultsColumn>
           {/* Wait for init, to prevent a flicker of info page before results are shown: */}
-          {!isShowingResults && isInitSearch && (
+          {isInitSearch && isDefaultQuery && (
             <projectConfig.components.SearchInfoPage />
           )}
           {isShowingResults && (

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -23,7 +23,7 @@ export const Search = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [isShowingResults, setShowingResults] = useState(false);
   const { searchQuery, searchParams, toFirstPage } = useSearchUrlParams();
-  const { isInitSearch, isLoadingSearch, defaultQuery } = useInitSearch();
+  const { isInitSearch, isLoadingSearch } = useInitSearch();
   const { getSearchResults } = useSearchResults();
   const {
     setSearchResults,
@@ -32,6 +32,7 @@ export const Search = () => {
     keywordFacets,
     addToHistory,
     searchResults,
+    defaultQuery,
   } = useSearchStore();
 
   useEffect(() => {

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -32,7 +32,6 @@ export const Search = () => {
     keywordFacets,
     addToHistory,
     searchResults,
-    defaultQuery,
   } = useSearchStore();
 
   useEffect(() => {
@@ -117,17 +116,8 @@ export const Search = () => {
     setDirty(true);
   }
 
-  const [isDefaultQuery, setIsDefaultQuery] = useState(false);
-  useEffect(() => {
-    const result = _.isEqual(defaultQuery, searchQuery);
-    console.log("isDefaultQuery?", { result, defaultQuery, searchQuery });
-    setIsDefaultQuery(result);
-  }, [defaultQuery, searchQuery, searchResults]);
-
   return (
     <div>
-      <p>Is default? {`${isDefaultQuery}`}</p>
-
       {isLoading && <SearchLoadingSpinner />}
 
       <div

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -23,7 +23,7 @@ export const Search = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [isShowingResults, setShowingResults] = useState(false);
   const { searchQuery, searchParams, toFirstPage } = useSearchUrlParams();
-  const { isInitSearch, isLoadingSearch } = useInitSearch();
+  const { isInitSearch, isLoadingSearch, defaultQuery } = useInitSearch();
   const { getSearchResults } = useSearchResults();
   const {
     setSearchResults,
@@ -116,8 +116,17 @@ export const Search = () => {
     setDirty(true);
   }
 
+  const [isDefaultQuery, setIsDefaultQuery] = useState(false);
+  useEffect(() => {
+    const result = _.isEqual(defaultQuery, searchQuery);
+    console.log("isDefaultQuery?", { result, defaultQuery, searchQuery });
+    setIsDefaultQuery(result);
+  }, [defaultQuery, searchQuery, searchResults]);
+
   return (
     <div>
+      <p>Is default? {`${isDefaultQuery}`}</p>
+
       {isLoading && <SearchLoadingSpinner />}
 
       <div

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -32,6 +32,7 @@ export const Search = () => {
     keywordFacets,
     addToHistory,
     searchResults,
+    defaultQuery,
   } = useSearchStore();
 
   useEffect(() => {
@@ -116,8 +117,17 @@ export const Search = () => {
     setDirty(true);
   }
 
+  const [isDefaultQuery, setIsDefaultQuery] = useState(false);
+  useEffect(() => {
+    const result = _.isEqual(defaultQuery, searchQuery);
+    console.log("isDefaultQuery?", { result, defaultQuery, searchQuery });
+    setIsDefaultQuery(result);
+  }, [defaultQuery, searchQuery, searchResults]);
+
   return (
     <div>
+      <p>Is default? {`${isDefaultQuery}`}</p>
+
       {isLoading && <SearchLoadingSpinner />}
 
       <div

--- a/src/components/Search/createSearchParams.tsx
+++ b/src/components/Search/createSearchParams.tsx
@@ -1,0 +1,18 @@
+import { ProjectConfig } from "../../model/ProjectConfig.ts";
+import { SearchParams } from "../../model/Search.ts";
+
+export const defaultSearchParams: SearchParams = {
+  indexName: "",
+  fragmentSize: 100,
+  from: 0,
+  size: 3,
+  sortBy: "_score",
+  sortOrder: "desc",
+};
+
+export function createSearchParams(props: { projectConfig: ProjectConfig }) {
+  return {
+    ...defaultSearchParams,
+    ...props.projectConfig.overrideDefaultSearchParams,
+  };
+}

--- a/src/components/Search/createSearchQuery.tsx
+++ b/src/components/Search/createSearchQuery.tsx
@@ -1,7 +1,7 @@
 import { ProjectConfig } from "../../model/ProjectConfig.ts";
 import { FacetEntry, NamedFacetAgg } from "../../model/Search.ts";
-import { blankSearchQuery } from "./useSearchUrlParams.tsx";
 import _ from "lodash";
+import { blankSearchQuery } from "../../stores/search/default-query-slice.ts";
 
 export function createSearchQuery(props: {
   projectConfig: ProjectConfig;

--- a/src/components/Search/createSearchQuery.tsx
+++ b/src/components/Search/createSearchQuery.tsx
@@ -1,0 +1,28 @@
+import { ProjectConfig } from "../../model/ProjectConfig.ts";
+import { FacetEntry, NamedFacetAgg } from "../../model/Search.ts";
+import { blankSearchQuery } from "./useSearchUrlParams.tsx";
+import _ from "lodash";
+
+export function createSearchQuery(props: {
+  projectConfig: ProjectConfig;
+  aggs?: NamedFacetAgg[];
+  dateFacets?: FacetEntry[];
+}) {
+  const { projectConfig, aggs, dateFacets } = props;
+
+  const configuredSearchQuery = {
+    ...blankSearchQuery,
+    dateFrom: projectConfig.initialDateFrom,
+    dateTo: projectConfig.initialDateTo,
+    rangeFrom: projectConfig.initialRangeFrom,
+    rangeTo: projectConfig.initialRangeTo,
+    aggs,
+  };
+  if (!_.isEmpty(dateFacets)) {
+    configuredSearchQuery.dateFacet = dateFacets?.[0]?.[0];
+  }
+  if (projectConfig.showSliderFacets) {
+    configuredSearchQuery.rangeFacet = "text.tokenCount";
+  }
+  return configuredSearchQuery;
+}

--- a/src/components/Search/createSearchQuery.tsx
+++ b/src/components/Search/createSearchQuery.tsx
@@ -1,5 +1,5 @@
 import { ProjectConfig } from "../../model/ProjectConfig.ts";
-import { FacetEntry, NamedFacetAgg } from "../../model/Search.ts";
+import { FacetEntry, NamedFacetAgg, SearchQuery } from "../../model/Search.ts";
 import _ from "lodash";
 import { blankSearchQuery } from "../../stores/search/default-query-slice.ts";
 
@@ -7,7 +7,7 @@ export function createSearchQuery(props: {
   projectConfig: ProjectConfig;
   aggs?: NamedFacetAgg[];
   dateFacets?: FacetEntry[];
-}) {
+}): SearchQuery {
   const { projectConfig, aggs, dateFacets } = props;
 
   const configuredSearchQuery = {

--- a/src/components/Search/useDefaultQuery.ts
+++ b/src/components/Search/useDefaultQuery.ts
@@ -19,7 +19,7 @@ import { handleAbort } from "../../utils/handleAbort.tsx";
 /**
  * The default query used when pressing enter in the full text input field
  * This includes facets that first need to be fetched from ES
- * and related properties (see {@link createSearchQuery}
+ * and related properties (see {@link createSearchQuery})
  */
 export function useDefaultQuery() {
   const projectConfig = useProjectStore(projectConfigSelector);

--- a/src/components/Search/useDefaultQuery.ts
+++ b/src/components/Search/useDefaultQuery.ts
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import { getElasticIndices } from "../../utils/broccoli.ts";
+import { toast } from "react-toastify";
+import { createAggs } from "./util/createAggs.ts";
+import { getFacets } from "./util/getFacets.ts";
+import { filterFacetsByType } from "../../stores/search/filterFacetsByType.ts";
+import { createSearchQuery } from "./createSearchQuery.tsx";
+import {
+  projectConfigSelector,
+  translateSelector,
+  useProjectStore,
+} from "../../stores/project.ts";
+import {
+  defaultQuerySettersSelector,
+  useSearchStore,
+} from "../../stores/search/search-store.ts";
+import { handleAbort } from "../../utils/handleAbort.tsx";
+
+export function useDefaultQuery() {
+  const projectConfig = useProjectStore(projectConfigSelector);
+  const translate = useProjectStore(translateSelector);
+
+  const [isInit, setIsInit] = useState(false);
+  const [isLoading, setLoading] = useState(false);
+
+  const { setKeywordFacets, setSearchFacetTypes, setDefaultQuery } =
+    useSearchStore(defaultQuerySettersSelector);
+
+  useEffect(() => {
+    if (isInit || isLoading) {
+      return;
+    }
+
+    setLoading(true);
+    const aborter = new AbortController();
+    init(aborter).catch(handleAbort);
+
+    return () => {
+      aborter.abort();
+    };
+
+    async function init(aborter: AbortController) {
+      const newIndices = await getElasticIndices(projectConfig, aborter.signal);
+      if (!newIndices) {
+        return toast(translate("NO_INDICES_FOUND"), { type: "error" });
+      }
+
+      const newFacetTypes = newIndices[projectConfig.elasticIndexName];
+
+      const newAggs = createAggs(newFacetTypes, projectConfig);
+
+      const blankQuery = createSearchQuery({ projectConfig });
+
+      const newFacets = await getFacets(
+        projectConfig,
+        newAggs,
+        blankQuery,
+        aborter.signal,
+      );
+
+      const newKeywordFacets = filterFacetsByType(
+        newFacetTypes,
+        newFacets,
+        "keyword",
+      );
+
+      const newDateFacets = filterFacetsByType(
+        newFacetTypes,
+        newFacets,
+        "date",
+      );
+
+      const newDefaultQuery = createSearchQuery({
+        projectConfig,
+        aggs: newAggs,
+        dateFacets: newDateFacets,
+      });
+
+      setSearchFacetTypes(newFacetTypes);
+      setDefaultQuery(newDefaultQuery);
+      setKeywordFacets(newKeywordFacets);
+
+      setLoading(false);
+      setIsInit(true);
+    }
+  }, []);
+
+  return {
+    isInitDefaultQuery: isInit,
+  };
+}

--- a/src/components/Search/useDefaultQuery.ts
+++ b/src/components/Search/useDefaultQuery.ts
@@ -16,6 +16,11 @@ import {
 } from "../../stores/search/search-store.ts";
 import { handleAbort } from "../../utils/handleAbort.tsx";
 
+/**
+ * The default query used when pressing enter in the full text input field
+ * This includes facets that first need to be fetched from ES
+ * and related properties (see {@link createSearchQuery}
+ */
 export function useDefaultQuery() {
   const projectConfig = useProjectStore(projectConfigSelector);
   const translate = useProjectStore(translateSelector);
@@ -49,12 +54,12 @@ export function useDefaultQuery() {
 
       const newAggs = createAggs(newFacetTypes, projectConfig);
 
-      const blankQuery = createSearchQuery({ projectConfig });
+      const projectConfigQuery = createSearchQuery({ projectConfig });
 
       const newFacets = await getFacets(
         projectConfig,
         newAggs,
-        blankQuery,
+        projectConfigQuery,
         aborter.signal,
       );
 

--- a/src/components/Search/useInitSearch.ts
+++ b/src/components/Search/useInitSearch.ts
@@ -7,6 +7,10 @@ import { isSearchableQuery } from "./isSearchableQuery.ts";
 import { useSearchResults } from "./useSearchResults.tsx";
 import { useDefaultQuery } from "./useDefaultQuery.ts";
 import _ from "lodash";
+import {
+  projectConfigSelector,
+  useProjectStore,
+} from "../../stores/project.ts";
 
 /**
  * Initialize search query, facets and (optional) results
@@ -15,6 +19,8 @@ import _ from "lodash";
  * - fetch results when {@link isSearchableQuery}
  */
 export function useInitSearch() {
+  const projectConfig = useProjectStore(projectConfigSelector);
+
   const { setSearchResults, setKeywordFacets, searchFacetTypes, defaultQuery } =
     useSearchStore();
   const { searchParams } = useSearchUrlParams();
@@ -43,14 +49,12 @@ export function useInitSearch() {
     setLoading(true);
 
     const newSearchQuery: SearchQuery = _.merge({}, defaultQuery, searchQuery);
-    console.log("new SearchQuery", {
-      defaultQuery,
-      searchQuery,
-      newSearchQuery,
-    });
     updateSearchQuery(newSearchQuery);
 
-    if (isSearchableQuery(newSearchQuery, defaultQuery)) {
+    if (
+      projectConfig.showSearchResultsOnInfoPage ||
+      isSearchableQuery(newSearchQuery, defaultQuery)
+    ) {
       const searchResults = await getSearchResults(
         searchFacetTypes,
         searchParams,

--- a/src/components/Search/useSearchUrlParams.tsx
+++ b/src/components/Search/useSearchUrlParams.tsx
@@ -6,11 +6,12 @@ import {
   getSearchQueryFromUrl,
 } from "../../utils/UrlParamUtils.ts";
 import { SearchParams, SearchQuery } from "../../model/Search.ts";
+import { useSearchStore } from "../../stores/search/search-store.ts";
+import { createSearchQuery } from "./createSearchQuery.tsx";
 import {
   projectConfigSelector,
   useProjectStore,
 } from "../../stores/project.ts";
-import { createSearchQuery } from "./createSearchQuery.tsx";
 
 /**
  * The url is our single source of truth.
@@ -20,11 +21,17 @@ import { createSearchQuery } from "./createSearchQuery.tsx";
  */
 export function useSearchUrlParams() {
   const [urlParams, setUrlParams] = useSearchParams();
+  const { defaultQuery } = useSearchStore();
   const projectConfig = useProjectStore(projectConfigSelector);
-
   const [searchQuery, setSearchQuery] = useState<SearchQuery>(
     getSearchQueryFromUrl(createSearchQuery({ projectConfig }), urlParams),
   );
+
+  useEffect(() => {
+    // Include all defaults once initialized:
+    getSearchQueryFromUrl(defaultQuery, urlParams);
+  }, [defaultQuery]);
+
   const [searchParams, setSearchParams] = useState<SearchParams>(
     getSearchParamsFromUrl(defaultSearchParams, urlParams),
   );
@@ -39,9 +46,9 @@ export function useSearchUrlParams() {
   }
 
   function updateSearchParams(update: Partial<SearchParams>): void {
-    console.log("updateSearchParams", update);
     updateUrl({ searchParams: { ...searchParams, ...update } });
   }
+
   function updateUrl(update: UpdatedUrlProps) {
     const updatedUrlParams = createUrlParams(
       Object.fromEntries(urlParams.entries()),
@@ -68,15 +75,6 @@ export function useSearchUrlParams() {
     toFirstPage,
   };
 }
-
-export const blankSearchQuery: SearchQuery = {
-  dateFrom: "",
-  dateTo: "",
-  rangeFrom: "",
-  rangeTo: "",
-  fullText: "",
-  terms: {},
-};
 
 export const defaultSearchParams: SearchParams = {
   indexName: "",

--- a/src/components/Search/useSearchUrlParams.tsx
+++ b/src/components/Search/useSearchUrlParams.tsx
@@ -1,16 +1,16 @@
 import { useSearchParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import {
+  createUrlParams,
   getSearchParamsFromUrl,
   getSearchQueryFromUrl,
-  createUrlParams,
 } from "../../utils/UrlParamUtils.ts";
 import { SearchParams, SearchQuery } from "../../model/Search.ts";
 import {
   projectConfigSelector,
   useProjectStore,
 } from "../../stores/project.ts";
-import { ProjectConfig } from "../../model/ProjectConfig.ts";
+import { createSearchQuery } from "./createSearchQuery.tsx";
 
 /**
  * The url is our single source of truth.
@@ -23,7 +23,7 @@ export function useSearchUrlParams() {
   const projectConfig = useProjectStore(projectConfigSelector);
 
   const [searchQuery, setSearchQuery] = useState<SearchQuery>(
-    getSearchQueryFromUrl(getDefaultQuery(projectConfig), urlParams),
+    getSearchQueryFromUrl(createSearchQuery({ projectConfig }), urlParams),
   );
   const [searchParams, setSearchParams] = useState<SearchParams>(
     getSearchParamsFromUrl(defaultSearchParams, urlParams),
@@ -67,20 +67,6 @@ export function useSearchUrlParams() {
     updateSearchParams,
     toFirstPage,
   };
-}
-
-export function getDefaultQuery(projectConfig: ProjectConfig) {
-  const configuredSearchQuery = {
-    ...blankSearchQuery,
-    dateFrom: projectConfig.initialDateFrom,
-    dateTo: projectConfig.initialDateTo,
-    rangeFrom: projectConfig.initialRangeFrom,
-    rangeTo: projectConfig.initialRangeTo,
-  };
-  if (projectConfig.showSliderFacets) {
-    configuredSearchQuery.rangeFacet = "text.tokenCount";
-  }
-  return configuredSearchQuery;
 }
 
 export const blankSearchQuery: SearchQuery = {

--- a/src/model/ProjectConfig.ts
+++ b/src/model/ProjectConfig.ts
@@ -98,6 +98,8 @@ type SearchConfig = {
   showSelectedFilters: boolean;
   showNewSearchButton: boolean;
   defaultKeywordAggsToRender: string[];
+  // TODO: config if project should show intro text
+  // TODO: overrideDefaultSearchParams: dateAsc for date
   overrideDefaultAggs: {
     facetName: string;
     order?: string;

--- a/src/model/ProjectConfig.ts
+++ b/src/model/ProjectConfig.ts
@@ -13,7 +13,9 @@ import {
   SearchQuery,
   SurianoSearchResultsBody,
   TranslatinSearchResultsBody,
+  VanGoghSearchResultsBody,
 } from "./Search.ts";
+import { MiradorConfig } from "./MiradorConfig.ts";
 
 export type ProjectConfig = SearchConfig &
   AnnotationConfig &
@@ -69,7 +71,8 @@ export type ComponentsConfig = {
       | TranslatinSearchResultsBody
       | MondriaanSearchResultsBody
       | GlobaliseSearchResultsBody
-      | SurianoSearchResultsBody;
+      | SurianoSearchResultsBody
+      | VanGoghSearchResultsBody;
   }) => JSX.Element;
   BrowseScanButtons: () => JSX.Element;
 };
@@ -200,7 +203,8 @@ export type ProjectSpecificConfig = Pick<
   ProjectConfig,
   ProjectSpecificProperties
 > &
-  // Make nested properties of components optional:
-  Omit<Partial<ProjectConfig>, "components"> & {
+  // Make nested config properties optional:
+  Omit<Partial<ProjectConfig>, "components" | "mirador"> & {
     components?: Partial<ComponentsConfig>;
+    mirador?: Partial<MiradorConfig>;
   };

--- a/src/model/ProjectConfig.ts
+++ b/src/model/ProjectConfig.ts
@@ -178,11 +178,7 @@ export type EntitySummaryDetailsProps = {
 
 export type CategoryGetter = (annoRepoBody: AnnoRepoBody) => string;
 
-/**
- * Omitted fields mirror {@link ProjectSpecificConfig}
- */
-export type DefaultConfig = Omit<
-  ProjectConfig,
+export type ProjectSpecificProperties =
   | "id"
   | "elasticIndexName"
   | "headerTitle"
@@ -193,26 +189,18 @@ export type DefaultConfig = Omit<
   | "maxRange"
   | "logoImageUrl"
   | "relativeTo"
-  | "headerColor"
+  | "headerColor";
+
+export type DefaultProjectConfig = Omit<
+  ProjectConfig,
+  ProjectSpecificProperties
 >;
 
-/**
- * Required fields mirror {@link DefaultConfig}
- */
 export type ProjectSpecificConfig = Pick<
   ProjectConfig,
-  | "id"
-  | "elasticIndexName"
-  | "headerTitle"
-  | "initialDateFrom"
-  | "initialDateTo"
-  | "initialRangeFrom"
-  | "initialRangeTo"
-  | "maxRange"
-  | "logoImageUrl"
-  | "relativeTo"
-  | "headerColor"
+  ProjectSpecificProperties
 > &
+  // Make nested properties of components optional:
   Omit<Partial<ProjectConfig>, "components"> & {
     components?: Partial<ComponentsConfig>;
   };

--- a/src/model/ProjectConfig.ts
+++ b/src/model/ProjectConfig.ts
@@ -100,6 +100,16 @@ type SearchConfig = {
   defaultKeywordAggsToRender: string[];
   // TODO: config if project should show intro text
   // TODO: overrideDefaultSearchParams: dateAsc for date
+
+  /**
+   * TODO
+   *  - twee config-opties
+   *    - intro-text-pagina
+   *      - renders no results but SearchInfoPage when defaultQuery
+   *    - intro-search-pagina
+   *      - renders SearchInfoPage + results when defaultQuery
+   */
+
   overrideDefaultAggs: {
     facetName: string;
     order?: string;

--- a/src/model/ProjectConfig.ts
+++ b/src/model/ProjectConfig.ts
@@ -100,14 +100,16 @@ type SearchConfig = {
   defaultKeywordAggsToRender: string[];
   // TODO: config if project should show intro text
   // TODO: overrideDefaultSearchParams: dateAsc for date
-
+  showSearchResultsOnInfoPage: boolean;
   /**
    * TODO
    *  - twee config-opties
    *    - intro-text-pagina
-   *      - renders no results but SearchInfoPage when defaultQuery
+   *      - renders SearchInfoPage when defaultQuery
+   *      - does not load search results when defaultQuery
    *    - intro-search-pagina
    *      - renders SearchInfoPage + results when defaultQuery
+   *      - also loads search results when defaultQuery
    */
 
   overrideDefaultAggs: {

--- a/src/model/ProjectConfig.ts
+++ b/src/model/ProjectConfig.ts
@@ -9,6 +9,7 @@ import {
   GlobaliseSearchResultsBody,
   MondriaanSearchResultsBody,
   RepublicSearchResultBody,
+  SearchParams,
   SearchQuery,
   TranslatinSearchResultsBody,
 } from "./Search.ts";
@@ -98,13 +99,14 @@ type SearchConfig = {
   showSelectedFilters: boolean;
   showNewSearchButton: boolean;
   defaultKeywordAggsToRender: string[];
-  // TODO: overrideDefaultSearchParams: dateAsc for date
   showSearchResultsOnInfoPage: boolean;
   overrideDefaultAggs: {
     facetName: string;
     order?: string;
     size?: number;
   }[];
+  // TODO: overrideDefaultSearchParams: dateAsc for date
+  overrideDefaultSearchParams: Partial<SearchParams>;
   allowEmptyStringSearch: boolean;
   showFacetFilter: boolean;
 };

--- a/src/model/ProjectConfig.ts
+++ b/src/model/ProjectConfig.ts
@@ -11,6 +11,7 @@ import {
   RepublicSearchResultBody,
   SearchParams,
   SearchQuery,
+  SurianoSearchResultsBody,
   TranslatinSearchResultsBody,
 } from "./Search.ts";
 
@@ -49,7 +50,7 @@ type FacsimileConfig = {
   };
 };
 
-type ComponentsConfig = {
+export type ComponentsConfig = {
   AnnotationButtons: () => JSX.Element;
   AnnotationItem: (props: AnnotationItemProps) => JSX.Element;
   AnnotationItemContent: (props: {
@@ -67,7 +68,8 @@ type ComponentsConfig = {
       | RepublicSearchResultBody
       | TranslatinSearchResultsBody
       | MondriaanSearchResultsBody
-      | GlobaliseSearchResultsBody;
+      | GlobaliseSearchResultsBody
+      | SurianoSearchResultsBody;
   }) => JSX.Element;
   BrowseScanButtons: () => JSX.Element;
 };
@@ -105,7 +107,6 @@ type SearchConfig = {
     order?: string;
     size?: number;
   }[];
-  // TODO: overrideDefaultSearchParams: dateAsc for date
   overrideDefaultSearchParams: Partial<SearchParams>;
   allowEmptyStringSearch: boolean;
   showFacetFilter: boolean;
@@ -176,3 +177,42 @@ export type EntitySummaryDetailsProps = {
 };
 
 export type CategoryGetter = (annoRepoBody: AnnoRepoBody) => string;
+
+/**
+ * Omitted fields mirror {@link ProjectSpecificConfig}
+ */
+export type DefaultConfig = Omit<
+  ProjectConfig,
+  | "id"
+  | "elasticIndexName"
+  | "headerTitle"
+  | "initialDateFrom"
+  | "initialDateTo"
+  | "initialRangeFrom"
+  | "initialRangeTo"
+  | "maxRange"
+  | "logoImageUrl"
+  | "relativeTo"
+  | "headerColor"
+>;
+
+/**
+ * Required fields mirror {@link DefaultConfig}
+ */
+export type ProjectSpecificConfig = Pick<
+  ProjectConfig,
+  | "id"
+  | "elasticIndexName"
+  | "headerTitle"
+  | "initialDateFrom"
+  | "initialDateTo"
+  | "initialRangeFrom"
+  | "initialRangeTo"
+  | "maxRange"
+  | "logoImageUrl"
+  | "relativeTo"
+  | "headerColor"
+> &
+  Omit<Partial<ProjectConfig>, "components"> & {
+    components?: Partial<ComponentsConfig>;
+  };

--- a/src/model/ProjectConfig.ts
+++ b/src/model/ProjectConfig.ts
@@ -98,20 +98,8 @@ type SearchConfig = {
   showSelectedFilters: boolean;
   showNewSearchButton: boolean;
   defaultKeywordAggsToRender: string[];
-  // TODO: config if project should show intro text
   // TODO: overrideDefaultSearchParams: dateAsc for date
   showSearchResultsOnInfoPage: boolean;
-  /**
-   * TODO
-   *  - twee config-opties
-   *    - intro-text-pagina
-   *      - renders SearchInfoPage when defaultQuery
-   *      - does not load search results when defaultQuery
-   *    - intro-search-pagina
-   *      - renders SearchInfoPage + results when defaultQuery
-   *      - also loads search results when defaultQuery
-   */
-
   overrideDefaultAggs: {
     facetName: string;
     order?: string;

--- a/src/projects/default/config/index.tsx
+++ b/src/projects/default/config/index.tsx
@@ -71,6 +71,7 @@ export const defaultConfig: Omit<
   histogramFacet: "",
   inputFacetOptions: "",
   overrideDefaultAggs: [],
+  overrideDefaultSearchParams: {},
   defaultKeywordAggsToRender: [],
   showFacetFilter: true,
   showPrevNextScanButtons: false,

--- a/src/projects/default/config/index.tsx
+++ b/src/projects/default/config/index.tsx
@@ -1,6 +1,6 @@
 import { Empty } from "../../../components/Empty.tsx";
 import { Placeholder } from "../../../components/Placeholder.tsx";
-import { DefaultConfig } from "../../../model/ProjectConfig.ts";
+import { DefaultProjectConfig } from "../../../model/ProjectConfig.ts";
 import { AnnotationItem } from "../AnnotationItem.tsx";
 import { AnnotationItemContent } from "../AnnotationItemContent.tsx";
 import { SearchItem } from "../SearchItem.tsx";
@@ -12,7 +12,7 @@ import { isEntity } from "./isEntity.ts";
  * Default configuration file with some sensible defaults
  * which can be extended and overwritten by projects
  */
-export const defaultConfig: DefaultConfig = {
+export const defaultConfig: DefaultProjectConfig = {
   broccoliUrl: "https://broccoli.tt.di.huc.knaw.nl",
   colours: {},
 

--- a/src/projects/default/config/index.tsx
+++ b/src/projects/default/config/index.tsx
@@ -99,4 +99,5 @@ export const defaultConfig: Omit<
     showWindowSideBar: false,
     showTopMenuButton: false,
   },
+  showSearchResultsOnInfoPage: false,
 };

--- a/src/projects/default/config/index.tsx
+++ b/src/projects/default/config/index.tsx
@@ -1,6 +1,6 @@
 import { Empty } from "../../../components/Empty.tsx";
 import { Placeholder } from "../../../components/Placeholder.tsx";
-import { ProjectConfig } from "../../../model/ProjectConfig.ts";
+import { DefaultConfig } from "../../../model/ProjectConfig.ts";
 import { AnnotationItem } from "../AnnotationItem.tsx";
 import { AnnotationItemContent } from "../AnnotationItemContent.tsx";
 import { SearchItem } from "../SearchItem.tsx";
@@ -12,20 +12,7 @@ import { isEntity } from "./isEntity.ts";
  * Default configuration file with some sensible defaults
  * which can be extended and overwritten by projects
  */
-export const defaultConfig: Omit<
-  ProjectConfig,
-  | "id"
-  | "elasticIndexName"
-  | "headerTitle"
-  | "initialDateFrom"
-  | "initialDateTo"
-  | "initialRangeFrom"
-  | "initialRangeTo"
-  | "maxRange"
-  | "logoImageUrl"
-  | "relativeTo"
-  | "headerColor"
-> = {
+export const defaultConfig: DefaultConfig = {
   broccoliUrl: "https://broccoli.tt.di.huc.knaw.nl",
   colours: {},
 

--- a/src/projects/globalise/config/index.tsx
+++ b/src/projects/globalise/config/index.tsx
@@ -1,6 +1,9 @@
 import merge from "lodash/merge";
 import logo from "../../../assets/G-1.png";
-import { ProjectConfig } from "../../../model/ProjectConfig.ts";
+import {
+  ProjectConfig,
+  ProjectSpecificConfig,
+} from "../../../model/ProjectConfig.ts";
 import { defaultConfig } from "../../default/config";
 import { AnnotationButtons } from "../AnnotationButtons.tsx";
 import { Help } from "../Help.tsx";
@@ -64,4 +67,4 @@ export const globaliseConfig: ProjectConfig = merge({}, defaultConfig, {
   mirador: {
     showWindowSideBar: true,
   },
-});
+} as ProjectSpecificConfig);

--- a/src/projects/hooft/config/index.tsx
+++ b/src/projects/hooft/config/index.tsx
@@ -1,6 +1,9 @@
 import merge from "lodash/merge";
 import logo from "../../../assets/logo-republic-temp.png";
-import { ProjectConfig } from "../../../model/ProjectConfig";
+import {
+  ProjectConfig,
+  ProjectSpecificConfig,
+} from "../../../model/ProjectConfig";
 import { defaultConfig } from "../../default/config";
 
 export const hooftConfig: ProjectConfig = merge({}, defaultConfig, {
@@ -22,4 +25,4 @@ export const hooftConfig: ProjectConfig = merge({}, defaultConfig, {
   showMirador: false,
   useExternalConfig: true,
   defaultKeywordAggsToRender: ["bodyType"],
-});
+} as ProjectSpecificConfig);

--- a/src/projects/mondriaan/config/index.tsx
+++ b/src/projects/mondriaan/config/index.tsx
@@ -1,6 +1,9 @@
 import merge from "lodash/merge";
 import logo from "../../../assets/logo-mondrian-papers.png";
-import { ProjectConfig } from "../../../model/ProjectConfig";
+import {
+  ProjectConfig,
+  ProjectSpecificConfig,
+} from "../../../model/ProjectConfig";
 import { defaultConfig } from "../../default/config";
 import AnnotationItem from "../AnnotationItem.tsx";
 import { AnnotationItemContent } from "../AnnotationItemContent.tsx";
@@ -135,4 +138,4 @@ export const mondriaanConfig: ProjectConfig = merge({}, defaultConfig, {
   mirador: {
     showTopMenuButton: true,
   },
-});
+} as ProjectSpecificConfig);

--- a/src/projects/republic/config/index.tsx
+++ b/src/projects/republic/config/index.tsx
@@ -1,6 +1,9 @@
 import merge from "lodash/merge";
 import logo from "../../../assets/logo-goetgevonden.png";
-import { ProjectConfig } from "../../../model/ProjectConfig";
+import {
+  ProjectConfig,
+  ProjectSpecificConfig,
+} from "../../../model/ProjectConfig";
 import { defaultConfig } from "../../default/config";
 import { EntitySummary } from "../annotation/EntitySummary.tsx";
 import {
@@ -129,4 +132,4 @@ export const republicConfig: ProjectConfig = merge({}, defaultConfig, {
     showTopMenuButton: true,
     showWindowSideBar: true,
   },
-});
+} as ProjectSpecificConfig);

--- a/src/projects/suriano/SearchInfoPage.tsx
+++ b/src/projects/suriano/SearchInfoPage.tsx
@@ -1,6 +1,6 @@
 export const SearchInfoPage = () => {
   return (
-    <div className="border-brand1Grey-100 -mx-10 mb-20 flex flex-row border-b px-10 pb-8">
+    <div className="border-brand1Grey-100 -mx-10 mb-20 border-b px-10 pb-8">
       <p className="mb-4 mt-4 block font-bold" style={{ maxWidth: "50em" }}>
         Welcome to the{" "}
         <span className="italic">

--- a/src/projects/suriano/SearchInfoPage.tsx
+++ b/src/projects/suriano/SearchInfoPage.tsx
@@ -1,14 +1,16 @@
 export const SearchInfoPage = () => {
   return (
-    <p className="mb-4 mt-4 block" style={{ maxWidth: "50em" }}>
-      Christofforo Suriano was the first Venetian envoy to the Dutch Republic.
-      His arrival in The Hague marks the beginning of official Dutch-Venetian
-      diplomatic relations. This digital edition presents all 725 letters sent
-      by Suriano to the Venetian Senate between 1616 and 1623, totaling
-      approximately 7,000 pages. His correspondence is of great importance for
-      Dutch, Venetian, and European history in the first phase of the Thirty
-      Years’ War. For more information about the edition, see:{" "}
-      <a href="https://suriano.huygens.knaw.nl/">suriano.huygens.knaw.nl</a>
-    </p>
+    <div className="border-brand1Grey-100 -mx-10 mb-20 flex flex-row border-b px-10 pb-8">
+      <p className="mb-10 mt-4 block" style={{ maxWidth: "50em" }}>
+        Christofforo Suriano was the first Venetian envoy to the Dutch Republic.
+        His arrival in The Hague marks the beginning of official Dutch-Venetian
+        diplomatic relations. This digital edition presents all 725 letters sent
+        by Suriano to the Venetian Senate between 1616 and 1623, totaling
+        approximately 7,000 pages. His correspondence is of great importance for
+        Dutch, Venetian, and European history in the first phase of the Thirty
+        Years’ War. For more information about the edition, see:{" "}
+        <a href="https://suriano.huygens.knaw.nl/">suriano.huygens.knaw.nl</a>
+      </p>
+    </div>
   );
 };

--- a/src/projects/suriano/config/index.tsx
+++ b/src/projects/suriano/config/index.tsx
@@ -118,4 +118,8 @@ export const surianoConfig: ProjectConfig = merge({}, defaultConfig, {
   selectedLanguage: "en",
   languages: [{ code: "en", labels: englishSurianoLabels }],
   showSearchResultsOnInfoPage: true,
+  overrideDefaultSearchParams: {
+    sortBy: "date",
+    sortOrder: "asc",
+  },
 } as ProjectSpecificConfig);

--- a/src/projects/suriano/config/index.tsx
+++ b/src/projects/suriano/config/index.tsx
@@ -123,3 +123,4 @@ export const surianoConfig: ProjectConfig = merge({}, defaultConfig, {
     sortOrder: "asc",
   },
 } as ProjectSpecificConfig);
+// TODO: Add search params to check if search results should be shown?

--- a/src/projects/suriano/config/index.tsx
+++ b/src/projects/suriano/config/index.tsx
@@ -1,6 +1,9 @@
 import merge from "lodash/merge";
 import logo from "../../../assets/logo-correspondense-of-Suriano.png";
-import { ProjectConfig } from "../../../model/ProjectConfig";
+import {
+  ProjectConfig,
+  ProjectSpecificConfig,
+} from "../../../model/ProjectConfig";
 import { defaultConfig } from "../../default/config";
 import { AnnotationButtons } from "../AnnotationButtons";
 import { MetadataPanel } from "../MetadataPanel";
@@ -115,4 +118,4 @@ export const surianoConfig: ProjectConfig = merge({}, defaultConfig, {
   selectedLanguage: "en",
   languages: [{ code: "en", labels: englishSurianoLabels }],
   showSearchResultsOnInfoPage: true,
-});
+} as ProjectSpecificConfig);

--- a/src/projects/suriano/config/index.tsx
+++ b/src/projects/suriano/config/index.tsx
@@ -114,4 +114,5 @@ export const surianoConfig: ProjectConfig = merge({}, defaultConfig, {
 
   selectedLanguage: "en",
   languages: [{ code: "en", labels: englishSurianoLabels }],
+  showSearchResultsOnInfoPage: true,
 });

--- a/src/projects/suriano/config/index.tsx
+++ b/src/projects/suriano/config/index.tsx
@@ -123,4 +123,3 @@ export const surianoConfig: ProjectConfig = merge({}, defaultConfig, {
     sortOrder: "asc",
   },
 } as ProjectSpecificConfig);
-// TODO: Add search params to check if search results should be shown?

--- a/src/projects/translatin/config/index.tsx
+++ b/src/projects/translatin/config/index.tsx
@@ -1,6 +1,9 @@
 import merge from "lodash/merge";
 import logo from "../../../assets/logo-republic-temp.png";
-import { ProjectConfig } from "../../../model/ProjectConfig";
+import {
+  ProjectConfig,
+  ProjectSpecificConfig,
+} from "../../../model/ProjectConfig";
 import { defaultConfig } from "../../default/config";
 import { MetadataPanel } from "../MetadataPanel";
 import { SearchItem } from "../SearchItem";
@@ -49,4 +52,4 @@ export const translatinConfig: ProjectConfig = merge({}, defaultConfig, {
 
   selectedLanguage: "nl",
   languages: [{ code: "nl", labels: dutchTranslatinLabels }],
-});
+} as ProjectSpecificConfig);

--- a/src/projects/vangogh/config/index.tsx
+++ b/src/projects/vangogh/config/index.tsx
@@ -1,6 +1,9 @@
 import merge from "lodash/merge";
 import logo from "../../../assets/logo-republic-temp.png";
-import { ProjectConfig } from "../../../model/ProjectConfig";
+import {
+  ProjectConfig,
+  ProjectSpecificConfig,
+} from "../../../model/ProjectConfig";
 import { defaultConfig } from "../../default/config";
 import { MetadataPanel } from "../MetadataPanel";
 import { SearchItem } from "../SearchItem";
@@ -103,4 +106,4 @@ export const vangoghConfig: ProjectConfig = merge({}, defaultConfig, {
   },
   selectedLanguage: "en",
   languages: [{ code: "en", labels: englishVanGoghLabels }],
-});
+} as ProjectSpecificConfig);

--- a/src/stores/search/default-query-slice.ts
+++ b/src/stores/search/default-query-slice.ts
@@ -1,0 +1,26 @@
+import { StateCreator } from "zustand";
+import { SearchQuery } from "../../model/Search.ts";
+
+export type DefaultQuerySlice = {
+  defaultQuery: SearchQuery;
+  setDefaultQuery: (update: SearchQuery) => void;
+};
+
+export const blankSearchQuery: SearchQuery = {
+  dateFrom: "",
+  dateTo: "",
+  rangeFrom: "",
+  rangeTo: "",
+  fullText: "",
+  terms: {},
+};
+
+export const createDefaultQuerySlice: StateCreator<
+  DefaultQuerySlice,
+  [],
+  [],
+  DefaultQuerySlice
+> = (set) => ({
+  defaultQuery: blankSearchQuery,
+  setDefaultQuery: (update) => set(() => ({ defaultQuery: update })),
+});

--- a/src/stores/search/search-store.ts
+++ b/src/stores/search/search-store.ts
@@ -15,15 +15,29 @@ import {
   createKeywordFacetsSlice,
   KeywordFacetsSlice,
 } from "./keyword-facets-slice.ts";
+import {
+  createDefaultQuerySlice,
+  DefaultQuerySlice,
+} from "./default-query-slice.ts";
 
-export type SearchStore = SearchResultsSlice &
+export type SearchStore = DefaultQuerySlice &
+  SearchResultsSlice &
   SearchHistorySlice &
   SearchFacetTypesSlice &
   KeywordFacetsSlice;
 
 export const useSearchStore = create<SearchStore>()((...a) => ({
+  ...createDefaultQuerySlice(...a),
   ...createKeywordFacetsSlice(...a),
   ...createSearchFacetTypesSlice(...a),
   ...createSearchResultsSlice(...a),
   ...createSearchHistorySlice(...a),
 }));
+
+export function defaultQuerySettersSelector(state: SearchStore) {
+  return {
+    setKeywordFacets: state.setKeywordFacets,
+    setSearchFacetTypes: state.setSearchFacetTypes,
+    setDefaultQuery: state.setDefaultQuery,
+  };
+}

--- a/src/utils/broccoli.ts
+++ b/src/utils/broccoli.ts
@@ -6,6 +6,7 @@ import {
   SearchQueryRequestBody,
   SearchResult,
 } from "../model/Search";
+import { Any } from "./Any.ts";
 import { Broccoli } from "../model/Broccoli.ts";
 
 const headers = {
@@ -55,12 +56,17 @@ export const sendSearchQuery = async (
 ): Promise<SearchResult | null> => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const urlSearchParams = new URLSearchParams(params as any);
+  // TODO: update broccoli to use new format:
+  const deprecatedSearchQuery = structuredClone(query);
+  deprecatedSearchQuery.aggs = Object.entries(query.aggs || {}).map(
+    (e) => `${e[0]}:${e[1].order},${e[1].size}`,
+  ) as Any;
   const response = await fetch(
     `${projectConfig.broccoliUrl}/projects/${projectConfig.id}/search?${urlSearchParams}`,
     {
       method: "POST",
       headers: headers,
-      body: JSON.stringify(query),
+      body: JSON.stringify(deprecatedSearchQuery),
       signal,
     },
   );

--- a/src/utils/broccoli.ts
+++ b/src/utils/broccoli.ts
@@ -6,7 +6,6 @@ import {
   SearchQueryRequestBody,
   SearchResult,
 } from "../model/Search";
-import { Any } from "./Any.ts";
 import { Broccoli } from "../model/Broccoli.ts";
 
 const headers = {
@@ -56,17 +55,12 @@ export const sendSearchQuery = async (
 ): Promise<SearchResult | null> => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const urlSearchParams = new URLSearchParams(params as any);
-  // TODO: update broccoli to use new format:
-  const deprecatedSearchQuery = structuredClone(query);
-  deprecatedSearchQuery.aggs = Object.entries(query.aggs || {}).map(
-    (e) => `${e[0]}:${e[1].order},${e[1].size}`,
-  ) as Any;
   const response = await fetch(
     `${projectConfig.broccoliUrl}/projects/${projectConfig.id}/search?${urlSearchParams}`,
     {
       method: "POST",
       headers: headers,
-      body: JSON.stringify(deprecatedSearchQuery),
+      body: JSON.stringify(query),
       signal,
     },
   );


### PR DESCRIPTION
This PR allows a project to configure and display search results on the search info page just below the info text:
 - add config property `showSearchResultsOnInfoPage` to configure if a project wants to display search results on the info page
 - add config property `overrideDefaultSearchParams` to allow a project to override the default search params.
 - add spacer between the info page and the search results

Also:
 - add type `ProjectSpecificConfig` to autocomplete project config objects
 - clean up [useSearchUrlParams.tsx](https://github.com/knaw-huc/textannoviz/compare/suriano-results-on-home?expand=1#diff-42c80cda675b8e449cb89e8cc4e1e0f28a4a1dc3fc94d36959353d7f6426b158)
- Add missing properties to default query, store fully configured default query in its own slice and move 'default query logic' to its own hook