### PR TITLE
Fix hidden reset date button when window is narrow than c. 1350px

### DIFF
--- a/src/components/Search/DateFacet.tsx
+++ b/src/components/Search/DateFacet.tsx
@@ -42,7 +42,7 @@ export function DateFacet(props: DateFacetProps) {
   }
 
   return (
-    <div className="flex w-full max-w-[450px] flex-col gap-4 lg:flex-row">
+    <div className="flex w-full max-w-[450px] flex-col gap-4 min-[1350px]:flex-row">
       <div className="flex w-full flex-col">
         <form>
           <label htmlFor="start" className="font-semibold">


### PR DESCRIPTION
Fixes #266. The current solution feels a bit hacky. Perhaps there is a better one?