### PR TITLE
Added Mirador redux store observer + keep track of current Mirador canvas in Zustand store

### DIFF
--- a/src/components/Detail/useInitDetail.tsx
+++ b/src/components/Detail/useInitDetail.tsx
@@ -1,15 +1,15 @@
-import { fetchBroccoliScanWithOverlap } from "../../utils/broccoli.ts";
 import { useEffect, useState } from "react";
+import { useAnnotationStore } from "../../stores/annotation.ts";
+import { useMiradorStore } from "../../stores/mirador.ts";
 import {
   projectConfigSelector,
   useProjectStore,
 } from "../../stores/project.ts";
+import { useTextStore } from "../../stores/text.ts";
+import { fetchBroccoliScanWithOverlap } from "../../utils/broccoli.ts";
 import { handleAbort } from "../../utils/handleAbort.tsx";
 import { NOTES_VIEW } from "../Text/Annotated/MarkerTooltip.tsx";
 import { useDetailUrl } from "../Text/Annotated/utils/useDetailUrl.tsx";
-import { useAnnotationStore } from "../../stores/annotation.ts";
-import { useTextStore } from "../../stores/text.ts";
-import { useMiradorStore } from "../../stores/mirador.ts";
 
 /**
  * Initialize views, annotations and iiif
@@ -24,6 +24,7 @@ export function useInitDetail() {
   const [isLoading, setLoading] = useState(false);
 
   const { setStore } = useMiradorStore();
+  const { setCurrentCanvas } = useMiradorStore();
   const { setAnnotations } = useAnnotationStore();
   const { setViews } = useTextStore();
 
@@ -105,6 +106,7 @@ export function useInitDetail() {
         bodyId: result.request.bodyId,
         iiif: result.iiif,
       });
+      setCurrentCanvas(result.iiif.canvasIds[0]);
       setAnnotations(annotations);
       setViews(views);
 

--- a/src/components/Footer/BrowseScanButtons.tsx
+++ b/src/components/Footer/BrowseScanButtons.tsx
@@ -1,9 +1,9 @@
 import mirador from "mirador-knaw-huc-mui5";
-import React from "react";
 import { Button } from "react-aria-components";
 import { CanvasTarget } from "../../model/AnnoRepoAnnotation";
 import { useAnnotationStore } from "../../stores/annotation";
 import { useInternalMiradorStore } from "../../stores/internal-mirador.ts";
+import { useMiradorStore } from "../../stores/mirador.ts";
 import {
   projectConfigSelector,
   translateSelector,
@@ -17,8 +17,8 @@ export function BrowseScanButtons() {
   const annotations = useAnnotationStore().annotations;
   const miradorStore = useInternalMiradorStore().miradorStore;
   const projectName = useProjectStore().projectName;
-  const [currentCanvas, setCurrentCanvas] = React.useState("");
   const pageAnnoType = projectConfig.pageAnnotation;
+  const { currentCanvas } = useMiradorStore();
 
   const pageAnnotations = annotations.filter(
     (anno) => anno.body.type === pageAnnoType,
@@ -32,19 +32,13 @@ export function BrowseScanButtons() {
 
   const firstCanvas = canvases[0];
   const lastCanvas = canvases[canvases.length - 1];
-  const miradorCanvas = miradorStore?.getState().windows[projectName]
-    .canvasId as string;
-
-  React.useEffect(() => {
-    setCurrentCanvas(miradorCanvas);
-  }, [miradorCanvas]);
 
   function prevCanvas() {
     miradorStore.dispatch(mirador.actions.setPreviousCanvas(projectName));
-    const newCanvas = miradorStore?.getState().windows[projectName]
-      .canvasId as string;
-    setCurrentCanvas(newCanvas);
     if (projectConfig.visualizeAnnosMirador) {
+      const newCanvas = miradorStore?.getState().windows[projectName]
+        .canvasId as string;
+
       visualizeAnnosMirador(
         annotations,
         miradorStore,
@@ -56,10 +50,10 @@ export function BrowseScanButtons() {
 
   function nextCanvas() {
     miradorStore.dispatch(mirador.actions.setNextCanvas(projectName));
-    const newCanvas = miradorStore?.getState().windows[projectName]
-      .canvasId as string;
-    setCurrentCanvas(newCanvas);
     if (projectConfig.visualizeAnnosMirador) {
+      const newCanvas = miradorStore?.getState().windows[projectName]
+        .canvasId as string;
+
       visualizeAnnosMirador(
         annotations,
         miradorStore,

--- a/src/components/Mirador/Mirador.tsx
+++ b/src/components/Mirador/Mirador.tsx
@@ -6,11 +6,12 @@ import { MiradorConfig } from "../../model/MiradorConfig";
 import { ProjectConfig } from "../../model/ProjectConfig";
 import { useAnnotationStore } from "../../stores/annotation";
 import { useInternalMiradorStore } from "../../stores/internal-mirador.ts";
+import { miradorSelector, useMiradorStore } from "../../stores/mirador.ts";
 import { projectConfigSelector, useProjectStore } from "../../stores/project";
 import { visualizeAnnosMirador } from "../../utils/visualizeAnnosMirador";
 import { defaultMiradorConfig } from "./defaultMiradorConfig";
+import { observeMiradorStore } from "./utils/observeMiradorStore.ts";
 import { zoomAnnoMirador } from "./zoomAnnoMirador";
-import { miradorSelector, useMiradorStore } from "../../stores/mirador.ts";
 
 export function Mirador() {
   const { annotations } = useAnnotationStore();
@@ -19,6 +20,9 @@ export function Mirador() {
   const setInternalMiradorStore = useInternalMiradorStore(
     (state) => state.setStore,
   );
+
+  const { setCurrentCanvas } = useMiradorStore();
+
   const miradorStore = useInternalMiradorStore((state) => state.miradorStore);
   const projectConfig = useProjectStore(projectConfigSelector);
   const showSvgsAnnosMirador = useAnnotationStore(
@@ -54,6 +58,10 @@ export function Mirador() {
     );
   }
 
+  function onCanvasChange(canvasId: string) {
+    setCurrentCanvas(canvasId);
+  }
+
   React.useEffect(() => {
     const viewer = mirador.viewer(miradorConfig);
     setInternalMiradorStore(viewer.store);
@@ -82,6 +90,8 @@ export function Mirador() {
     }
 
     function performPostInitialisationActions() {
+      observeMiradorStore(viewer.store, projectConfig.id, onCanvasChange);
+
       if (projectConfig.zoomAnnoMirador) {
         zoomAnnoMirador(bodyId, annotations, iiif, viewer.store, projectConfig);
       }

--- a/src/components/Mirador/utils/observeMiradorStore.ts
+++ b/src/components/Mirador/utils/observeMiradorStore.ts
@@ -1,0 +1,26 @@
+import { Any } from "../../../utils/Any";
+
+export function observeMiradorStore(
+  store: Any,
+  windowId: string,
+  onCanvasChange: (canvasId: string) => void,
+) {
+  let currentValue: string | undefined;
+
+  function handleCanvasChange() {
+    const previousValue = currentValue;
+    currentValue = store.getState().windows[windowId].canvasId;
+
+    if (!previousValue) return;
+
+    if (currentValue && previousValue !== currentValue) {
+      onCanvasChange(currentValue);
+    }
+  }
+
+  handleCanvasChange();
+
+  const unsubscribe = store.subscribe(handleCanvasChange);
+
+  return unsubscribe;
+}

--- a/src/stores/mirador.ts
+++ b/src/stores/mirador.ts
@@ -10,6 +10,13 @@ export type MiradorSlice = {
 export type MiradorInitSlice = Optional<MiradorSlice, "bodyId" | "iiif">;
 export type MiradorState = Omit<MiradorSlice, "setStore">;
 
+export type MiradorCurrentCanvasSlice = {
+  currentCanvas: string;
+  setCurrentCanvas: (newCanvas: string) => void;
+};
+
+type MiradorStore = MiradorInitSlice & MiradorCurrentCanvasSlice;
+
 const createMiradorSlice: StateCreator<
   MiradorInitSlice,
   [],
@@ -21,8 +28,19 @@ const createMiradorSlice: StateCreator<
   setStore: (update) => set(() => ({ ...update })),
 });
 
-export const useMiradorStore = create<MiradorInitSlice>()((...a) => ({
+const createMiradorCurrentCanvasSlice: StateCreator<
+  MiradorCurrentCanvasSlice,
+  [],
+  [],
+  MiradorCurrentCanvasSlice
+> = (set) => ({
+  currentCanvas: "",
+  setCurrentCanvas: (newCanvas) => set(() => ({ currentCanvas: newCanvas })),
+});
+
+export const useMiradorStore = create<MiradorStore>()((...a) => ({
   ...createMiradorSlice(...a),
+  ...createMiradorCurrentCanvasSlice(...a),
 }));
 
 export function miradorSelector(state: MiradorInitSlice): MiradorSlice {


### PR DESCRIPTION
Fixes #178.

This PR adds:
- Observer on the internal Mirador Redux store to better track changes in the internal Mirador state
- Zustand slice for keeping track of the current canvas displayed in Mirador

Using the current canvas state from the Zustand store in the `BrowseScanButtons` component (combined with the new observer) fixes the link issue between the prev/next scan buttons and the page break markers. Previously, when the user clicked on one of the page markers, the prev/next scan buttons still thought the user was on the first scan. Now, the (state behind the) prev/next scan buttons update correctly when the user clicks one of the page markers.