### PR TITLE
Improve allowCloseTextPanel logic

### DIFF
--- a/src/components/Text/TextPanel.tsx
+++ b/src/components/Text/TextPanel.tsx
@@ -29,14 +29,14 @@ export const TextPanel = (props: TextPanelProps) => {
           {translateProject(`${props.panel}`)}
         </span>
 
-        <button
-          onClick={() => props.closePanelHandler(props.panel)}
-          className="rounded p-2"
-        >
-          {projectConfig.allowCloseTextPanel && (
+        {projectConfig.allowCloseTextPanel && (
+          <button
+            onClick={() => props.closePanelHandler(props.panel)}
+            className="rounded p-2"
+          >
             <XMarkIcon className="h-6 fill-neutral-500 stroke-neutral-800" />
-          )}
-        </button>
+          </button>
+        )}
       </div>
 
       <div className="mx-auto flex max-w-3xl" role="textpanel">


### PR DESCRIPTION
Moved the `projectConfig.allowCloseTextPanel` check to the outer button instead of only the icon. Previously, when `allowCloseTextPanel` was false, the button was still rendered, meaning the user could still press the invisible button to close the text panel. With the improved logic in this PR, the entire button is not rendered when `allowCloseTextPanel` is set to false.