### PR TITLE
Fix sorting search results, and updating results per page and fragmenter

### DIFF
--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,28 +1,28 @@
 import _ from "lodash";
 import React, { useEffect, useState } from "react";
+import { SearchParams, SearchQuery } from "../../model/Search.ts";
 import {
   projectConfigSelector,
   useProjectStore,
 } from "../../stores/project.ts";
+import { filterFacetsByType } from "../../stores/search/filterFacetsByType.ts";
 import { useSearchStore } from "../../stores/search/search-store.ts";
+import { toRequestBody } from "../../stores/search/toRequestBody.ts";
 import { sendSearchQuery } from "../../utils/broccoli";
+import { handleAbort } from "../../utils/handleAbort.tsx";
 import { SearchForm } from "./SearchForm.tsx";
 import { SearchLoadingSpinner } from "./SearchLoadingSpinner.tsx";
 import { SearchResults, SearchResultsColumn } from "./SearchResults.tsx";
-import { useSearchResults } from "./useSearchResults.tsx";
-import { handleAbort } from "../../utils/handleAbort.tsx";
-import { useSearchUrlParams } from "./useSearchUrlParams.tsx";
-import { toRequestBody } from "../../stores/search/toRequestBody.ts";
-import { filterFacetsByType } from "../../stores/search/filterFacetsByType.ts";
-import { SearchParams, SearchQuery } from "../../model/Search.ts";
 import { useInitSearch } from "./useInitSearch.ts";
+import { useSearchResults } from "./useSearchResults.tsx";
+import { useSearchUrlParams } from "./useSearchUrlParams.tsx";
 
 export const Search = () => {
   const projectConfig = useProjectStore(projectConfigSelector);
   const [isDirty, setDirty] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isShowingResults, setShowingResults] = useState(false);
-  const { searchQuery, searchParams, toFirstPage } = useSearchUrlParams();
+  const { searchQuery, searchParams } = useSearchUrlParams();
   const { isInitSearch, isLoadingSearch } = useInitSearch();
   const { getSearchResults } = useSearchResults();
   const {
@@ -109,7 +109,6 @@ export const Search = () => {
   }
 
   function handleNewSearch() {
-    toFirstPage();
     setDirty(true);
   }
 

--- a/src/components/Search/SearchResults.tsx
+++ b/src/components/Search/SearchResults.tsx
@@ -17,8 +17,8 @@ import { SearchResultsPerPage } from "./SearchResultsPerPage.tsx";
 import { SearchSorting, Sorting } from "./SearchSorting.tsx";
 import { Histogram } from "./histogram/Histogram.tsx";
 import { HistogramControls } from "./histogram/HistogramControls.tsx";
-import { removeTerm } from "./util/removeTerm.ts";
 import { useSearchUrlParams } from "./useSearchUrlParams.tsx";
+import { removeTerm } from "./util/removeTerm.ts";
 
 type SearchResultsProps = {
   query: SearchQuery;
@@ -59,6 +59,8 @@ export function SearchResults(props: SearchResultsProps) {
     updateSearchParams({
       sortBy: sorting.field,
       sortOrder: sorting.order,
+      //bring user back to first page
+      from: 0,
     });
     props.onSearch();
   }
@@ -90,6 +92,8 @@ export function SearchResults(props: SearchResultsProps) {
     }
     updateSearchParams({
       size: key as number,
+      //bring user back to first page
+      from: 0,
     });
     props.onSearch();
   };

--- a/src/components/Search/SearchResultsPerPage.tsx
+++ b/src/components/Search/SearchResultsPerPage.tsx
@@ -21,7 +21,6 @@ export const SearchResultsPerPage = (props: SearchResultsPerPageProps) => {
   const { searchParams } = useSearchUrlParams();
   const [selectedKey, setSelectedKey] = React.useState<Key>(searchParams.size);
   const options: PageSizeOption[] = [
-    { name: 3 },
     { name: 10 },
     { name: 20 },
     { name: 50 },

--- a/src/components/Search/useSearchUrlParams.tsx
+++ b/src/components/Search/useSearchUrlParams.tsx
@@ -1,4 +1,9 @@
 import { useEffect, useState } from "react";
+import { SearchParams, SearchQuery } from "../../model/Search.ts";
+import {
+  projectConfigSelector,
+  useProjectStore,
+} from "../../stores/project.ts";
 import {
   cleanUrlParams,
   encodeSearchQuery,
@@ -7,13 +12,8 @@ import {
   getUrlParams,
   pushUrlParamsToHistory,
 } from "../../utils/UrlParamUtils.ts";
-import { SearchParams, SearchQuery } from "../../model/Search.ts";
-import { createSearchQuery } from "./createSearchQuery.tsx";
-import {
-  projectConfigSelector,
-  useProjectStore,
-} from "../../stores/project.ts";
 import { createSearchParams } from "./createSearchParams.tsx";
+import { createSearchQuery } from "./createSearchQuery.tsx";
 
 /**
  * The url is our single source of truth.
@@ -59,15 +59,10 @@ export function useSearchUrlParams() {
     pushUrlParamsToHistory(cleanUrlParams({ ...searchParams, ...update }));
   }
 
-  function toFirstPage() {
-    updateSearchParams({ from: 0 });
-  }
-
   return {
     searchQuery,
     updateSearchQuery,
     searchParams,
     updateSearchParams,
-    toFirstPage,
   };
 }


### PR DESCRIPTION
The problem occurred due to the asynchronicity of the React State updates. The `searchParams` is a React State, and when the user updates, e.g., the sorting of the search results, the state is updated twice in one render: once to update the sorting, and once to bring the user back to the first page (through the `toFirstPage()` function). Seeing as everything happens in one render, the second `searchParams` updater (fired through the `toFirstPage()` function) does not yet have access to the new state, meaning that the `searchParams` are overwritten with the previous state.

This PR removes the `toFirstPage()` function and moves the logic to the respective updaters (sort search results and results per page) to resolve the issues with the asynchronous nature of React State updates.

Fixes #338.