### PR TITLE
Prevent loading all project stylesheets

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,6 +77,7 @@ export default function App() {
 function Layout() {
   return (
     <>
+      <style>{config.projectCss}</style>
       <Header projectConfig={config} />
       <Outlet />
     </>

--- a/src/model/ProjectConfig.ts
+++ b/src/model/ProjectConfig.ts
@@ -35,6 +35,7 @@ export type ProjectConfig = SearchConfig &
     showWebAnnoTab: boolean;
 
     components: ComponentsConfig;
+    projectCss: string;
   };
 
 type FacsimileConfig = {

--- a/src/projects/default/config/index.tsx
+++ b/src/projects/default/config/index.tsx
@@ -88,4 +88,5 @@ export const defaultConfig: DefaultProjectConfig = {
     showTopMenuButton: false,
   },
   showSearchResultsOnInfoPage: false,
+  projectCss: "",
 };

--- a/src/projects/suriano/config/index.tsx
+++ b/src/projects/suriano/config/index.tsx
@@ -7,7 +7,6 @@ import {
 import { defaultConfig } from "../../default/config";
 import { AnnotationButtons } from "../AnnotationButtons";
 import { MetadataPanel } from "../MetadataPanel";
-import "../project.css";
 import { SearchItem } from "../SearchItem";
 import { englishSurianoLabels } from "./englishSurianoLabels";
 
@@ -24,6 +23,8 @@ import {
 } from "../annotation/ProjectAnnotationModel.ts";
 import { SearchInfoPage } from "../SearchInfoPage.tsx";
 import { Empty } from "../../../components/Empty.tsx";
+
+import projectCss from "../project.css?inline";
 
 export const surianoConfig: ProjectConfig = merge({}, defaultConfig, {
   id: "suriano",
@@ -122,4 +123,5 @@ export const surianoConfig: ProjectConfig = merge({}, defaultConfig, {
     sortBy: "date",
     sortOrder: "asc",
   },
+  projectCss: projectCss,
 } as ProjectSpecificConfig);


### PR DESCRIPTION
Prevent loading all project stylesheets by importing them as a string, and applying only the relevant one