### PR TITLE
Lazy load detail, help and search routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,8 @@ import "primereact/resources/primereact.min.css";
 import "primereact/resources/themes/bootstrap4-light-blue/theme.css";
 import { createBrowserRouter, Outlet, RouterProvider } from "react-router-dom";
 import { Header } from "./components/Header";
-import Help from "./components/Help";
-import { Search } from "./components/Search/Search";
-import { detailTier2Path } from "./components/Text/Annotated/utils/detailPath.ts";
-import { Detail } from "./Detail";
+
+import { detailPath } from "./components/Text/Annotated/utils/detailPath.ts";
 import { ErrorPage } from "./ErrorPage";
 import { ExternalConfig } from "./model/ExternalConfig";
 import { ProjectConfig } from "./model/ProjectConfig";
@@ -16,6 +14,12 @@ import {
   setProjectNameSelector,
   useProjectStore,
 } from "./stores/project";
+import { lazy, Suspense } from "react";
+import { SearchLoadingSpinner } from "./components/Search/SearchLoadingSpinner.tsx";
+
+const Detail = lazy(() => import("./Detail"));
+const Help = lazy(() => import("./components/Help"));
+const Search = lazy(() => import("./components/Search/Search"));
 
 const { project, config } = selectProjectConfig();
 const router = await createRouter();
@@ -71,7 +75,11 @@ export default function App() {
   setProjectConfig(config);
   setProjectName(project);
 
-  return <RouterProvider router={router} />;
+  return (
+    <Suspense fallback={<SearchLoadingSpinner />}>
+      <RouterProvider router={router} />
+    </Suspense>
+  );
 }
 
 function Layout() {
@@ -94,7 +102,7 @@ async function createRouter() {
           element: <Search />,
         },
         {
-          path: detailTier2Path,
+          path: detailPath,
           element: <Detail project={project} config={config} />,
         },
         {

--- a/src/Detail.tsx
+++ b/src/Detail.tsx
@@ -14,7 +14,7 @@ interface DetailProps {
   config: ProjectConfig;
 }
 
-export const Detail = (props: DetailProps) => {
+const Detail = (props: DetailProps) => {
   const [showSearchResults, setShowSearchResults] = useState(false);
   const [showIiifViewer, setShowIiifViewer] = useState(true);
   const [showAnnotationPanel, setShowAnnotationPanel] = useState(
@@ -72,3 +72,5 @@ export const Detail = (props: DetailProps) => {
     </>
   );
 };
+
+export default Detail;

--- a/src/components/Detail/useDetailNavigation.tsx
+++ b/src/components/Detail/useDetailNavigation.tsx
@@ -8,7 +8,7 @@ import { SearchResult } from "../../model/Search.ts";
 import { useSearchStore } from "../../stores/search/search-store.ts";
 import { LAST_SEARCH_RESULT } from "../Search/SearchUrlParams.ts";
 import _ from "lodash";
-import { detailTier2Path } from "../Text/Annotated/utils/detailPath.ts";
+import { detailPath } from "../Text/Annotated/utils/detailPath.ts";
 
 export type DetailUrlSearchParams = {
   highlight?: string;
@@ -53,9 +53,8 @@ export function useDetailNavigation() {
       setUrlParams(nextUrlSearchParams, cleanUrlParams(props.params));
     }
 
-    const nextTier2 = matchPath(detailTier2Path, path)?.params.tier2;
-    const currentTier2 = matchPath(detailTier2Path, location.pathname)?.params
-      .tier2;
+    const nextTier2 = matchPath(detailPath, path)?.params.tier2;
+    const currentTier2 = matchPath(detailPath, location.pathname)?.params.tier2;
 
     updateLastSearchResultParam({
       nextUrlSearchParams,
@@ -147,7 +146,7 @@ function updateLastSearchResultParam(props: {
     return;
   }
 
-  const isOnDetailPage = !!matchPath(detailTier2Path, location.pathname);
+  const isOnDetailPage = !!matchPath(detailPath, location.pathname);
   if (!isOnDetailPage) {
     nextUrlSearchParams.delete(LAST_SEARCH_RESULT);
     return;

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -17,7 +17,7 @@ import { useInitSearch } from "./useInitSearch.ts";
 import { useSearchResults } from "./useSearchResults.tsx";
 import { useSearchUrlParams } from "./useSearchUrlParams.tsx";
 
-export const Search = () => {
+const Search = () => {
   const projectConfig = useProjectStore(projectConfigSelector);
   const [isDirty, setDirty] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -151,3 +151,5 @@ export const Search = () => {
     </React.Fragment>
   );
 };
+
+export default Search;

--- a/src/components/Text/Annotated/utils/detailPath.ts
+++ b/src/components/Text/Annotated/utils/detailPath.ts
@@ -1,2 +1,1 @@
-export const detailPrefix = `detail/`;
-export const detailTier2Path = `${detailPrefix}:tier2`;
+export const detailPath = `detail/:tier2`;


### PR DESCRIPTION
Experiment with lazy loading the detail, help and search routes to improve load time and facilitate code splitting. Also: rename detailTier2Path to detailPath.

Reduces main index file from 2.4 to 1.7mb. 
Routes:
- Detail: 176kb
- Search: 438kb
- Help: 118b
