### PR TITLE
Add basename to React Router to allow TAV to run on subdomains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 #Possible options: "republic", "globalise", "mondriaan", "translatin", "suriano", "hooft", or "vangogh"
 VITE_PROJECT=republic
 VITE_TITLE=Textannoviz - Republic
+VITE_ROUTER_BASENAME=/

--- a/scripts/docker-build-push.sh
+++ b/scripts/docker-build-push.sh
@@ -6,6 +6,7 @@ if [[
   || -z $PROJECT \
   || -z $TITLE \
   || -z $TAG \
+  || -z $ROUTER_BASENAME
 ]]; then
   echo 'missing required env vars'
   exit 1
@@ -14,9 +15,18 @@ fi
 sed \
   -e "/^VITE_PROJECT=/s/=.*/=$PROJECT/" \
   -e "/^VITE_TITLE=/s/=.*/=$TITLE/" \
+  -e "/^VITE_ROUTER_BASENAME=/s|=.*|=$ROUTER_BASENAME|" \
   .env.example \
   > .env
 
 docker build -t $TAG --platform=linux/amd64 -f deploy/Dockerfile-deploy .
 
 docker push $TAG
+
+#Reset VITE_ROUTER_BASENAME back to "/" in .env
+sed \
+  -e "/^VITE_PROJECT=/s/=.*/=$PROJECT/" \
+  -e "/^VITE_TITLE=/s/=.*/=$TITLE/" \
+  -e "/^VITE_ROUTER_BASENAME=/s/=.*/=\//" \
+  .env.example \
+  > .env

--- a/scripts/docker-globalise-all.sh
+++ b/scripts/docker-globalise-all.sh
@@ -5,5 +5,7 @@ DOCKER_DOMAIN=registry.diginfra.net/tt
 PROJECT=globalise
 TITLE="Textannoviz - Globalise"
 TAG=${DOCKER_DOMAIN}/textannoviz-${PROJECT}-frontend:${VERSION}
+#ROUTER_BASENAME needs to be set to the subdomain TAV will run at on the server. If it runs at root level, it needs to be set to "/". For the preview environment, this needs to be set to "/app".
+export ROUTER_BASENAME="/"
 
 ./scripts/docker-build-push.sh

--- a/scripts/docker-globalise-demo-all.sh
+++ b/scripts/docker-globalise-demo-all.sh
@@ -5,5 +5,7 @@ export DOCKER_DOMAIN=registry.diginfra.net/tt
 export PROJECT=globalise
 export TITLE="Globalise Transcriptions Viewer"
 export TAG=${DOCKER_DOMAIN}/textannoviz-${PROJECT}-demo-frontend:${VERSION}
+#ROUTER_BASENAME needs to be set to the subdomain TAV will run at on the server. If it runs at root level, it needs to be set to "/". For the preview environment, this needs to be set to "/app".
+export ROUTER_BASENAME="/"
 
 ./scripts/docker-build-push.sh

--- a/scripts/docker-hooft-all.sh
+++ b/scripts/docker-hooft-all.sh
@@ -5,5 +5,7 @@ export DOCKER_DOMAIN=registry.diginfra.net/tt
 export PROJECT=hooft
 export TITLE="Textannoviz - Hooft"
 export TAG=${DOCKER_DOMAIN}/textannoviz-${PROJECT}-frontend:${VERSION}
+#ROUTER_BASENAME needs to be set to the subdomain TAV will run at on the server. If it runs at root level, it needs to be set to "/". For the preview environment, this needs to be set to "/app".
+export ROUTER_BASENAME="/"
 
 ./scripts/docker-build-push.sh

--- a/scripts/docker-mondriaan-all.sh
+++ b/scripts/docker-mondriaan-all.sh
@@ -5,5 +5,7 @@ export DOCKER_DOMAIN=registry.diginfra.net/tt
 export PROJECT=mondriaan
 export TITLE="Textannoviz - Mondriaan"
 export TAG=${DOCKER_DOMAIN}/textannoviz-${PROJECT}-frontend:${VERSION}
+#ROUTER_BASENAME needs to be set to the subdomain TAV will run at on the server. If it runs at root level, it needs to be set to "/". For the preview environment, this needs to be set to "/app".
+export ROUTER_BASENAME="/"
 
 ./scripts/docker-build-push.sh

--- a/scripts/docker-republic-all.sh
+++ b/scripts/docker-republic-all.sh
@@ -5,5 +5,7 @@ export DOCKER_DOMAIN=registry.diginfra.net/tt
 export PROJECT=republic
 export TITLE="Textannoviz - Republic"
 export TAG=${DOCKER_DOMAIN}/textannoviz-${PROJECT}-frontend:${VERSION}
+#ROUTER_BASENAME needs to be set to the subdomain TAV will run at on the server. If it runs at root level, it needs to be set to "/". For the preview environment, this needs to be set to "/app".
+export ROUTER_BASENAME="/"
 
 ./scripts/docker-build-push.sh

--- a/scripts/docker-republic-prod-all.sh
+++ b/scripts/docker-republic-prod-all.sh
@@ -5,5 +5,7 @@ export DOCKER_DOMAIN=registry.diginfra.net/tt
 export PROJECT=republic
 export TITLE="Goetgevonden - applicatie"
 export TAG=${DOCKER_DOMAIN}/textannoviz-${PROJECT}-prod-frontend:${VERSION}
+#ROUTER_BASENAME needs to be set to the subdomain TAV will run at on the server. If it runs at root level, it needs to be set to "/". For the preview environment, this needs to be set to "/app".
+export ROUTER_BASENAME="/"
 
 ./scripts/docker-build-push.sh

--- a/scripts/docker-republic-test-all.sh
+++ b/scripts/docker-republic-test-all.sh
@@ -5,5 +5,7 @@ export DOCKER_DOMAIN=registry.diginfra.net/tt
 export PROJECT=republic
 export TITLE="Textannoviz - Republic"
 export TAG=${DOCKER_DOMAIN}/textannoviz-${PROJECT}-test-frontend:${VERSION}
+#ROUTER_BASENAME needs to be set to the subdomain TAV will run at on the server. If it runs at root level, it needs to be set to "/". For the preview environment, this needs to be set to "/app".
+export ROUTER_BASENAME="/"
 
 ./scripts/docker-build-push.sh

--- a/scripts/docker-suriano-all.sh
+++ b/scripts/docker-suriano-all.sh
@@ -4,5 +4,7 @@ export DOCKER_DOMAIN=registry.diginfra.net/tt
 export PROJECT=suriano
 export TITLE="Textannoviz - Suriano"
 export TAG=${DOCKER_DOMAIN}/textannoviz-${PROJECT}-frontend:${VERSION}
+#ROUTER_BASENAME needs to be set to the subdomain TAV will run at on the server. If it runs at root level, it needs to be set to "/". For the preview environment, this needs to be set to "/app".
+export ROUTER_BASENAME="/"
 
 ./scripts/docker-build-push.sh

--- a/scripts/docker-translatin-all.sh
+++ b/scripts/docker-translatin-all.sh
@@ -5,5 +5,7 @@ export DOCKER_DOMAIN=registry.diginfra.net/tt
 export PROJECT=translatin
 export TITLE="Textannoviz - Translatin"
 export TAG=${DOCKER_DOMAIN}/textannoviz-${PROJECT}-frontend:${VERSION}
+#ROUTER_BASENAME needs to be set to the subdomain TAV will run at on the server. If it runs at root level, it needs to be set to "/". For the preview environment, this needs to be set to "/app".
+export ROUTER_BASENAME="/"
 
 ./scripts/docker-build-push.sh

--- a/scripts/docker-vangogh-all.sh
+++ b/scripts/docker-vangogh-all.sh
@@ -5,5 +5,7 @@ export DOCKER_DOMAIN=registry.diginfra.net/tt
 export PROJECT=vangogh
 export TITLE="Textannoviz - Van Gogh"
 export TAG=${DOCKER_DOMAIN}/textannoviz-${PROJECT}-frontend:${VERSION}
+#ROUTER_BASENAME needs to be set to the subdomain TAV will run at on the server. If it runs at root level, it needs to be set to "/". For the preview environment, this needs to be set to "/app".
+export ROUTER_BASENAME="/"
 
 ./scripts/docker-build-push.sh

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,26 +85,29 @@ function Layout() {
 }
 
 async function createRouter() {
-  return createBrowserRouter([
-    {
-      element: <Layout />,
-      errorElement: <ErrorPage />,
-      children: [
-        {
-          path: "/",
-          element: <Search />,
-        },
-        {
-          path: detailTier2Path,
-          element: <Detail project={project} config={config} />,
-        },
-        {
-          path: "help",
-          element: <Help project={project} config={config} />,
-        },
-      ],
-    },
-  ]);
+  return createBrowserRouter(
+    [
+      {
+        element: <Layout />,
+        errorElement: <ErrorPage />,
+        children: [
+          {
+            path: "/",
+            element: <Search />,
+          },
+          {
+            path: detailTier2Path,
+            element: <Detail project={project} config={config} />,
+          },
+          {
+            path: "help",
+            element: <Help project={project} config={config} />,
+          },
+        ],
+      },
+    ],
+    { basename: import.meta.env["VITE_ROUTER_BASENAME"] ?? "/" },
+  );
 }
 
 function selectProjectConfig() {


### PR DESCRIPTION
In the 🥕 preview environment, TAV runs at the "/app" subdomain. For the internal React routing to work correctly with this subdomain, `basename` must be added to the React Router. This PR adds `basename` to the React Router and makes it configurable via the local .env, so the correct `basename` is set during build time. When the new Van Gogh or Israels data is available, we can create a 🥕-specific shell script for this project where `ROUTER_BASENAME` is set to `"/app"`.