### PR TITLE
Fix comma bug

### DIFF
--- a/src/components/Detail/useDetailNavigation.tsx
+++ b/src/components/Detail/useDetailNavigation.tsx
@@ -55,7 +55,7 @@ export function useDetailNavigation() {
       ),
     });
 
-    navigate(`${path}?${getUrlParams()}`);
+    navigate(`${path}${getUrlParams()}`);
   }
 
   function getDetailParams(): DetailTierAndParams {
@@ -67,7 +67,7 @@ export function useDetailNavigation() {
   }
 
   function createDetailUrl(resultId: string) {
-    return `/detail/${resultId}?${getUrlParams()}`;
+    return `/detail/${resultId}${getUrlParams()}`;
   }
 
   /**

--- a/src/components/Detail/useDetailNavigation.tsx
+++ b/src/components/Detail/useDetailNavigation.tsx
@@ -1,9 +1,9 @@
 import { matchPath, Params, useNavigate, useParams } from "react-router-dom";
-import { getUrlParams } from "../../utils/UrlParamUtils.ts";
+import { decodeObject, getUrlParams } from "../../utils/UrlParamUtils.ts";
 import { SearchResult } from "../../model/Search.ts";
 import { useSearchStore } from "../../stores/search/search-store.ts";
 import { LAST_SEARCH_RESULT } from "../Search/SearchUrlParams.ts";
-import { isString, isNumber } from "lodash";
+import { isNumber, isString } from "lodash";
 import { detailTier2Path } from "../Text/Annotated/utils/detailPath.ts";
 import { useUrlSearchParamsStore } from "../Search/useSearchUrlParamsStore.ts";
 
@@ -84,7 +84,9 @@ export function useDetailNavigation() {
       return params.tier2;
     }
 
-    const lastSearchResultParam = getUrlParams().get(LAST_SEARCH_RESULT);
+    const lastSearchResultParam = decodeObject(getUrlParams())[
+      LAST_SEARCH_RESULT
+    ] as string;
     if (
       lastSearchResultParam &&
       searchResults &&

--- a/src/utils/UrlParamUtils.ts
+++ b/src/utils/UrlParamUtils.ts
@@ -84,8 +84,8 @@ export function decodeObject(encoded: string | null) {
   });
 }
 
-export function getUrlParams(): URLSearchParams {
-  return new URLSearchParams(window.location.search);
+export function getUrlParams(): string {
+  return window.location.search;
 }
 
 export type UpdateOrRemoveParams = {

--- a/src/utils/UrlParamUtils.ts
+++ b/src/utils/UrlParamUtils.ts
@@ -74,14 +74,18 @@ export function encodeObject(decoded: object): string {
   });
 }
 
-export function decodeObject(encoded: string | null) {
-  if (!encoded) {
-    return {};
-  }
+function decodeUrlParams(encoded: string) {
   return qs.parse(encoded, {
     ignoreQueryPrefix: true,
     comma: true,
   });
+}
+
+export function decodeObject(encoded: string | null) {
+  if (!encoded) {
+    return {};
+  }
+  return decodeUrlParams(encoded);
 }
 
 export function getUrlParams(): string {
@@ -99,9 +103,7 @@ export type UpdateOrRemoveParams = {
 export function pushUrlParamsToHistory(params: UpdateOrRemoveParams) {
   const { toUpdate, toRemove } = params;
   const urlUpdate = new URL(window.location.toString());
-  const paramUpdate = qs.parse(window.location.search, {
-    ignoreQueryPrefix: true,
-  });
+  const paramUpdate = decodeUrlParams(getUrlParams());
   if (toRemove) {
     for (const key of toRemove) {
       delete paramUpdate[key];
@@ -122,7 +124,7 @@ export function pushUrlParamsToHistory(params: UpdateOrRemoveParams) {
 export function getStateFromUrl<T extends object>(
   template: T,
 ): UrlStateItem<T> {
-  const urlParams = decodeObject(window.location.search);
+  const urlParams = decodeObject(getUrlParams());
   return { urlState: getTypedParamsFromUrl(template, urlParams) };
 }
 


### PR DESCRIPTION
When reloading this url, the comma's get encoded/decoded wrongly: http://localhost:5173/detail/urn:republic:inv-3146-date-1601-08-04-session-146-resolution-7?query[terms][propositionType]=onbekend,missive

When encoding an array using qs, it should also be decoded by qs. Or if the unparsed string is wanted, `getUrlParams` can be used.
