### PR TITLE
Add subdomain to external config fetch

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,12 @@ const { project, config } = selectProjectConfig();
 const router = await createRouter();
 
 async function fetchExternalConfig(): Promise<ExternalConfig | null> {
-  const response = await fetch("/config");
+  const basePath = (import.meta.env["VITE_ROUTER_BASENAME"] as string) ?? "/";
+  const configUrl = `${
+    basePath.endsWith("/") ? basePath : basePath + "/"
+  }config`;
+
+  const response = await fetch(configUrl);
   if (!response.ok) {
     return null;
   }


### PR DESCRIPTION
Previously, the fetch for the external config.json used an absolute path. This caused issues when running TAV behind a subdomain, like `/app`, as TAV would try to fetch the config from `/config` instead of `/app/config`. TAV now supports subdomains (see #356), so this PR adds that subdomain support to the external config fetch. Based on this branch, I have built a version of TAV that runs correctly on https://preview.dev.diginfra.org/app without the previously required reroute in nginx from `/config` to `/app/config`. See [this commit](https://code.huc.knaw.nl/tt/editem/-/commit/6b1b3b4294e246071cf524f71c0d5cacf10c2b9e) for the removal of the reroute. 