### PR TITLE
Set base path for production build using VITE_ROUTER_BASENAME

### DIFF
--- a/vite.config.prod.ts
+++ b/vite.config.prod.ts
@@ -63,5 +63,6 @@ export default defineConfig(({ mode }) => {
     build: {
       target: "esnext",
     },
+    base: env.VITE_ROUTER_BASENAME ?? "/",
   };
 });


### PR DESCRIPTION
This PR adds the subdomain to the production build using the same `VITE_ROUTER_BASENAME` env var as used in the Router (#356, #360). This change adds the subdomain before the `/assets` path in the `index.html`.