### PR TITLE
Added panels with tabs to detail page

### DIFF
--- a/src/Detail.tsx
+++ b/src/Detail.tsx
@@ -1,6 +1,5 @@
 import { Skeleton } from "primereact/skeleton";
 import { useState } from "react";
-import { Annotation } from "./components/Annotations/Annotation.tsx";
 import { Footer } from "./components/Footer/Footer";
 // import { Mirador } from "./components/Mirador/Mirador";
 import { useInitDetail } from "./components/Detail/useInitDetail.tsx";
@@ -21,7 +20,7 @@ export const Detail = (props: DetailProps) => {
   const [showAnnotationPanel, setShowAnnotationPanel] = useState(
     props.config.defaultShowMetadataPanel,
   );
-  const { isInitDetail, isLoadingDetail } = useInitDetail();
+  const { isInitDetail } = useInitDetail();
   const { isInitSearch } = useInitSearch();
 
   const globalSearchResults = useSearchStore((state) => state.searchResults);
@@ -50,9 +49,9 @@ export const Detail = (props: DetailProps) => {
               allPossiblePanels={props.config.allPossibleTextPanels}
               isLoading={isLoadingDetail}
             /> */}
-            {showAnnotationPanel ? (
+            {/* {showAnnotationPanel ? (
               <Annotation isLoading={isLoadingDetail} />
-            ) : null}
+            ) : null} */}
           </main>
           <Footer
             showIiifViewerHandler={showIiifViewerHandler}

--- a/src/Detail.tsx
+++ b/src/Detail.tsx
@@ -2,12 +2,13 @@ import { Skeleton } from "primereact/skeleton";
 import { useState } from "react";
 import { Annotation } from "./components/Annotations/Annotation.tsx";
 import { Footer } from "./components/Footer/Footer";
-import { Mirador } from "./components/Mirador/Mirador";
-import { TextComponent } from "./components/Text/TextComponent";
-import { ProjectConfig } from "./model/ProjectConfig";
-import { useSearchStore } from "./stores/search/search-store";
+// import { Mirador } from "./components/Mirador/Mirador";
+import { Panel } from "./components/Detail/Panel.tsx";
 import { useInitDetail } from "./components/Detail/useInitDetail.tsx";
 import { useInitSearch } from "./components/Search/useInitSearch.ts";
+// import { TextComponent } from "./components/Text/TextComponent";
+import { ProjectConfig } from "./model/ProjectConfig";
+import { useSearchStore } from "./stores/search/search-store";
 
 interface DetailProps {
   project: string;
@@ -42,12 +43,13 @@ export const Detail = (props: DetailProps) => {
       {isInitDetail && isInitSearch ? (
         <>
           <main className="mx-auto flex h-full w-full grow flex-row content-stretch items-stretch self-stretch">
-            {showIiifViewer && props.config.showMirador ? <Mirador /> : null}
-            <TextComponent
+            <Panel />
+            {/* {showIiifViewer && props.config.showMirador ? <Mirador /> : null} */}
+            {/* <TextComponent
               panelsToRender={props.config.defaultTextPanels}
               allPossiblePanels={props.config.allPossibleTextPanels}
               isLoading={isLoadingDetail}
-            />
+            /> */}
             {showAnnotationPanel ? (
               <Annotation isLoading={isLoadingDetail} />
             ) : null}

--- a/src/Detail.tsx
+++ b/src/Detail.tsx
@@ -1,11 +1,9 @@
 import { Skeleton } from "primereact/skeleton";
 import { useState } from "react";
-import { Footer } from "./components/Footer/Footer";
-// import { Mirador } from "./components/Mirador/Mirador";
-import { useInitDetail } from "./components/Detail/useInitDetail.tsx";
-import { useInitSearch } from "./components/Search/useInitSearch.ts";
-// import { TextComponent } from "./components/Text/TextComponent";
 import { Panels } from "./components/Detail/Panels.tsx";
+import { useInitDetail } from "./components/Detail/useInitDetail.tsx";
+import { Footer } from "./components/Footer/Footer";
+import { useInitSearch } from "./components/Search/useInitSearch.ts";
 import { ProjectConfig } from "./model/ProjectConfig";
 import { useSearchStore } from "./stores/search/search-store";
 
@@ -43,15 +41,6 @@ export const Detail = (props: DetailProps) => {
         <>
           <main className="mx-auto flex h-full w-full grow flex-row content-stretch items-stretch self-stretch">
             <Panels />
-            {/* {showIiifViewer && props.config.showMirador ? <Mirador /> : null} */}
-            {/* <TextComponent
-              panelsToRender={props.config.defaultTextPanels}
-              allPossiblePanels={props.config.allPossibleTextPanels}
-              isLoading={isLoadingDetail}
-            /> */}
-            {/* {showAnnotationPanel ? (
-              <Annotation isLoading={isLoadingDetail} />
-            ) : null} */}
           </main>
           <Footer
             showIiifViewerHandler={showIiifViewerHandler}

--- a/src/Detail.tsx
+++ b/src/Detail.tsx
@@ -3,10 +3,10 @@ import { useState } from "react";
 import { Annotation } from "./components/Annotations/Annotation.tsx";
 import { Footer } from "./components/Footer/Footer";
 // import { Mirador } from "./components/Mirador/Mirador";
-import { Panel } from "./components/Detail/Panel.tsx";
 import { useInitDetail } from "./components/Detail/useInitDetail.tsx";
 import { useInitSearch } from "./components/Search/useInitSearch.ts";
 // import { TextComponent } from "./components/Text/TextComponent";
+import { Panels } from "./components/Detail/Panels.tsx";
 import { ProjectConfig } from "./model/ProjectConfig";
 import { useSearchStore } from "./stores/search/search-store";
 
@@ -43,7 +43,7 @@ export const Detail = (props: DetailProps) => {
       {isInitDetail && isInitSearch ? (
         <>
           <main className="mx-auto flex h-full w-full grow flex-row content-stretch items-stretch self-stretch">
-            <Panel />
+            <Panels />
             {/* {showIiifViewer && props.config.showMirador ? <Mirador /> : null} */}
             {/* <TextComponent
               panelsToRender={props.config.defaultTextPanels}

--- a/src/components/Detail/MetadataTab.tsx
+++ b/src/components/Detail/MetadataTab.tsx
@@ -1,0 +1,15 @@
+import { useAnnotationStore } from "../../stores/annotation";
+import { projectConfigSelector, useProjectStore } from "../../stores/project";
+
+export const MetadataTab = () => {
+  const projectConfig = useProjectStore(projectConfigSelector);
+  const { annotations } = useAnnotationStore();
+
+  return (
+    <div className="text-brand1-800 h-full p-5">
+      {annotations.length > 0 ? (
+        <projectConfig.components.MetadataPanel annotations={annotations} />
+      ) : null}
+    </div>
+  );
+};

--- a/src/components/Detail/MiradorTab.tsx
+++ b/src/components/Detail/MiradorTab.tsx
@@ -1,0 +1,5 @@
+import { Mirador } from "../Mirador/Mirador";
+
+export const MiradorTab = () => {
+  return <Mirador />;
+};

--- a/src/components/Detail/Panel.tsx
+++ b/src/components/Detail/Panel.tsx
@@ -25,8 +25,8 @@ export const Panel = (props: PanelProps) => {
   return (
     <>
       <Tabs
-        className={`border-brand1Grey-100 flex h-[calc(100vh-100px)] w-7/12 flex-col overflow-auto border-x ${
-          !isOpen ? "w-8 overflow-hidden" : ""
+        className={`border-brand1Grey-100 flex h-[calc(100vh-100px)] w-7/12 flex-col overflow-hidden border-x ${
+          !isOpen ? "w-8" : ""
         }`}
       >
         <div className="flex flex-row">

--- a/src/components/Detail/Panel.tsx
+++ b/src/components/Detail/Panel.tsx
@@ -30,7 +30,10 @@ export const Panel = (props: PanelProps) => {
         }`}
       >
         <div className="flex flex-row">
-          <Button className="text-sm" onPress={() => setIsOpen(!isOpen)}>
+          <Button
+            className="px-2 text-sm outline-none"
+            onPress={() => setIsOpen(!isOpen)}
+          >
             {isOpen ? "Close" : "Open"}
           </Button>
 

--- a/src/components/Detail/Panel.tsx
+++ b/src/components/Detail/Panel.tsx
@@ -1,4 +1,6 @@
+import React from "react";
 import {
+  Button,
   Collection,
   Tab,
   TabList,
@@ -11,35 +13,52 @@ type PanelProps = {
     title: string;
     content: JSX.Element;
   }[];
-  name: string;
+  panelName: string;
 };
 
 export const Panel = (props: PanelProps) => {
+  const [isOpen, setIsOpen] = React.useState(true);
+
   const tabStyling =
     "aria-selected:bg-brand1Grey-100 hover:bg-brand1Grey-50 px-4 py-2 outline-none transition-colors duration-200 hover:cursor-pointer";
 
   return (
-    <Tabs className="border-brand1Grey-100 flex h-[calc(100vh-100px)] w-7/12 flex-col overflow-auto border-x">
-      <TabList
-        className="border-brand1Grey-100 sticky top-0 flex w-full border-b bg-white text-sm text-neutral-600"
-        items={props.tabsToRender}
-      >
-        {(item) => (
-          <Tab
-            id={`${props.name}-${item.title.toLowerCase()}`}
-            className={tabStyling}
-          >
-            {item.title}
-          </Tab>
-        )}
-      </TabList>
-      <Collection items={props.tabsToRender}>
-        {(item) => (
-          <TabPanel id={`${props.name}-${item.title.toLowerCase()}`}>
-            {item.content}
-          </TabPanel>
-        )}
-      </Collection>
-    </Tabs>
+    <>
+      <>
+        <Tabs
+          className={`border-brand1Grey-100 flex h-[calc(100vh-100px)] w-7/12 flex-col overflow-auto border-x ${
+            !isOpen ? "w-8 overflow-hidden" : ""
+          }`}
+        >
+          <div className="flex flex-row">
+            <Button className="text-sm" onPress={() => setIsOpen(!isOpen)}>
+              {isOpen ? "Close" : "Open"}
+            </Button>
+
+            <TabList className="border-brand1Grey-100 sticky top-0 flex w-full border-b bg-white text-sm text-neutral-600">
+              {props.tabsToRender.map((item) => (
+                <Tab
+                  key={item.title}
+                  id={`${props.panelName}-${item.title.toLowerCase()}`}
+                  className={tabStyling}
+                >
+                  {item.title}
+                </Tab>
+              ))}
+            </TabList>
+          </div>
+
+          {isOpen ? (
+            <Collection items={props.tabsToRender}>
+              {(item) => (
+                <TabPanel id={`${props.panelName}-${item.title.toLowerCase()}`}>
+                  {item.content}
+                </TabPanel>
+              )}
+            </Collection>
+          ) : null}
+        </Tabs>
+      </>
+    </>
   );
 };

--- a/src/components/Detail/Panel.tsx
+++ b/src/components/Detail/Panel.tsx
@@ -1,38 +1,34 @@
-import { Tab, TabList, TabPanel, Tabs } from "react-aria-components";
-import { projectConfigSelector, useProjectStore } from "../../stores/project";
-import { Mirador } from "../Mirador/Mirador";
-import { TextComponent } from "../Text/TextComponent";
-import { useInitDetail } from "./useInitDetail";
+import {
+  Collection,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
+} from "react-aria-components";
 
-export const Panel = () => {
-  const projectConfig = useProjectStore(projectConfigSelector);
-  const { isLoadingDetail } = useInitDetail();
+type PanelProps = {
+  tabsToRender: {
+    id: number;
+    title: string;
+    content: JSX.Element;
+  }[];
+};
+
+export const Panel = (props: PanelProps) => {
+  const tabStyling =
+    "aria-selected:bg-brand1Grey-100 hover:bg-brand1Grey-50 px-4 py-2 outline-none transition-colors duration-200 hover:cursor-pointer";
+
   return (
     <Tabs className="border-brand1Grey-100 flex h-[calc(100vh-100px)] w-7/12 flex-col overflow-auto border-x">
-      <TabList className="border-brand1Grey-100 sticky top-0 flex w-full border-b bg-white text-sm text-neutral-600">
-        <Tab
-          id="facsimile"
-          className="aria-selected:bg-brand1Grey-100 hover:bg-brand1Grey-50 px-4 py-2 outline-none transition-colors duration-200 hover:cursor-pointer"
-        >
-          Facsimile
-        </Tab>
-        <Tab
-          id="text"
-          className="aria-selected:bg-brand1Grey-100 hover:bg-brand1Grey-50 px-4 py-2 outline-none transition-colors duration-200 hover:cursor-pointer"
-        >
-          Text
-        </Tab>
+      <TabList
+        className="border-brand1Grey-100 sticky top-0 flex w-full border-b bg-white text-sm text-neutral-600"
+        items={props.tabsToRender}
+      >
+        {(item) => <Tab className={tabStyling}>{item.title}</Tab>}
       </TabList>
-      <TabPanel id="facsimile">
-        <Mirador />
-      </TabPanel>
-      <TabPanel id="text">
-        <TextComponent
-          panelsToRender={projectConfig.defaultTextPanels}
-          allPossiblePanels={projectConfig.allPossibleTextPanels}
-          isLoading={isLoadingDetail}
-        />
-      </TabPanel>
+      <Collection items={props.tabsToRender}>
+        {(item) => <TabPanel>{item.content}</TabPanel>}
+      </Collection>
     </Tabs>
   );
 };

--- a/src/components/Detail/Panel.tsx
+++ b/src/components/Detail/Panel.tsx
@@ -1,0 +1,38 @@
+import { Tab, TabList, TabPanel, Tabs } from "react-aria-components";
+import { projectConfigSelector, useProjectStore } from "../../stores/project";
+import { Mirador } from "../Mirador/Mirador";
+import { TextComponent } from "../Text/TextComponent";
+import { useInitDetail } from "./useInitDetail";
+
+export const Panel = () => {
+  const projectConfig = useProjectStore(projectConfigSelector);
+  const { isLoadingDetail } = useInitDetail();
+  return (
+    <Tabs className="border-brand1Grey-100 flex h-[calc(100vh-100px)] w-7/12 flex-col overflow-auto border-x">
+      <TabList className="border-brand1Grey-100 sticky top-0 flex w-full border-b bg-white text-sm text-neutral-600">
+        <Tab
+          id="facsimile"
+          className="aria-selected:bg-brand1Grey-100 hover:bg-brand1Grey-50 px-4 py-2 outline-none transition-colors duration-200 hover:cursor-pointer"
+        >
+          Facsimile
+        </Tab>
+        <Tab
+          id="text"
+          className="aria-selected:bg-brand1Grey-100 hover:bg-brand1Grey-50 px-4 py-2 outline-none transition-colors duration-200 hover:cursor-pointer"
+        >
+          Text
+        </Tab>
+      </TabList>
+      <TabPanel id="facsimile">
+        <Mirador />
+      </TabPanel>
+      <TabPanel id="text">
+        <TextComponent
+          panelsToRender={projectConfig.defaultTextPanels}
+          allPossiblePanels={projectConfig.allPossibleTextPanels}
+          isLoading={isLoadingDetail}
+        />
+      </TabPanel>
+    </Tabs>
+  );
+};

--- a/src/components/Detail/Panel.tsx
+++ b/src/components/Detail/Panel.tsx
@@ -24,41 +24,39 @@ export const Panel = (props: PanelProps) => {
 
   return (
     <>
-      <>
-        <Tabs
-          className={`border-brand1Grey-100 flex h-[calc(100vh-100px)] w-7/12 flex-col overflow-auto border-x ${
-            !isOpen ? "w-8 overflow-hidden" : ""
-          }`}
-        >
-          <div className="flex flex-row">
-            <Button className="text-sm" onPress={() => setIsOpen(!isOpen)}>
-              {isOpen ? "Close" : "Open"}
-            </Button>
+      <Tabs
+        className={`border-brand1Grey-100 flex h-[calc(100vh-100px)] w-7/12 flex-col overflow-auto border-x ${
+          !isOpen ? "w-8 overflow-hidden" : ""
+        }`}
+      >
+        <div className="flex flex-row">
+          <Button className="text-sm" onPress={() => setIsOpen(!isOpen)}>
+            {isOpen ? "Close" : "Open"}
+          </Button>
 
-            <TabList className="border-brand1Grey-100 sticky top-0 flex w-full border-b bg-white text-sm text-neutral-600">
-              {props.tabsToRender.map((item) => (
-                <Tab
-                  key={item.title}
-                  id={`${props.panelName}-${item.title.toLowerCase()}`}
-                  className={tabStyling}
-                >
-                  {item.title}
-                </Tab>
-              ))}
-            </TabList>
-          </div>
+          <TabList className="border-brand1Grey-100 sticky top-0 flex w-full border-b bg-white text-sm text-neutral-600">
+            {props.tabsToRender.map((item) => (
+              <Tab
+                key={item.title}
+                id={`${props.panelName}-${item.title.toLowerCase()}`}
+                className={tabStyling}
+              >
+                {item.title}
+              </Tab>
+            ))}
+          </TabList>
+        </div>
 
-          {isOpen ? (
-            <Collection items={props.tabsToRender}>
-              {(item) => (
-                <TabPanel id={`${props.panelName}-${item.title.toLowerCase()}`}>
-                  {item.content}
-                </TabPanel>
-              )}
-            </Collection>
-          ) : null}
-        </Tabs>
-      </>
+        {isOpen ? (
+          <Collection items={props.tabsToRender}>
+            {(item) => (
+              <TabPanel id={`${props.panelName}-${item.title.toLowerCase()}`}>
+                {item.content}
+              </TabPanel>
+            )}
+          </Collection>
+        ) : null}
+      </Tabs>
     </>
   );
 };

--- a/src/components/Detail/Panel.tsx
+++ b/src/components/Detail/Panel.tsx
@@ -8,10 +8,10 @@ import {
 
 type PanelProps = {
   tabsToRender: {
-    id: number;
     title: string;
     content: JSX.Element;
   }[];
+  name: string;
 };
 
 export const Panel = (props: PanelProps) => {
@@ -24,10 +24,21 @@ export const Panel = (props: PanelProps) => {
         className="border-brand1Grey-100 sticky top-0 flex w-full border-b bg-white text-sm text-neutral-600"
         items={props.tabsToRender}
       >
-        {(item) => <Tab className={tabStyling}>{item.title}</Tab>}
+        {(item) => (
+          <Tab
+            id={`${props.name}-${item.title.toLowerCase()}`}
+            className={tabStyling}
+          >
+            {item.title}
+          </Tab>
+        )}
       </TabList>
       <Collection items={props.tabsToRender}>
-        {(item) => <TabPanel>{item.content}</TabPanel>}
+        {(item) => (
+          <TabPanel id={`${props.name}-${item.title.toLowerCase()}`}>
+            {item.content}
+          </TabPanel>
+        )}
       </Collection>
     </Tabs>
   );

--- a/src/components/Detail/Panels.tsx
+++ b/src/components/Detail/Panels.tsx
@@ -3,21 +3,38 @@ import { Panel } from "./Panel";
 import { TextComponentTab } from "./TextComponentTab";
 
 export const Panels = () => {
-  const tabs = [
+  const panels = [
     {
-      id: 1,
-      title: "Facsimile",
-      content: <MiradorTab />,
+      name: "facs-text",
+      tabs: [
+        {
+          id: 1,
+          title: "Facsimile",
+          content: <MiradorTab />,
+        },
+        {
+          id: 2,
+          title: "Text",
+          content: <TextComponentTab />,
+        },
+      ],
     },
     {
-      id: 2,
-      title: "Text",
-      content: <TextComponentTab />,
+      name: "text",
+      tabs: [
+        {
+          id: 3,
+          title: "Text",
+          content: <TextComponentTab />,
+        },
+      ],
     },
   ];
   return (
     <>
-      <Panel tabsToRender={tabs} />
+      {panels.map((panel, index) => (
+        <Panel key={index} tabsToRender={panel.tabs} />
+      ))}
     </>
   );
 };

--- a/src/components/Detail/Panels.tsx
+++ b/src/components/Detail/Panels.tsx
@@ -5,7 +5,7 @@ export const Panels = () => {
   const projectConfig = useProjectStore(projectConfigSelector);
   return (
     <>
-      {projectConfig.panels.map((panel, index) => (
+      {projectConfig.detailPanels.map((panel, index) => (
         <Panel key={index} tabsToRender={panel.tabs} panelName={panel.name} />
       ))}
     </>

--- a/src/components/Detail/Panels.tsx
+++ b/src/components/Detail/Panels.tsx
@@ -1,0 +1,23 @@
+import { MiradorTab } from "./MiradorTab";
+import { Panel } from "./Panel";
+import { TextComponentTab } from "./TextComponentTab";
+
+export const Panels = () => {
+  const tabs = [
+    {
+      id: 1,
+      title: "Facsimile",
+      content: <MiradorTab />,
+    },
+    {
+      id: 2,
+      title: "Text",
+      content: <TextComponentTab />,
+    },
+  ];
+  return (
+    <>
+      <Panel tabsToRender={tabs} />
+    </>
+  );
+};

--- a/src/components/Detail/Panels.tsx
+++ b/src/components/Detail/Panels.tsx
@@ -1,36 +1,12 @@
-import { MiradorTab } from "./MiradorTab";
+import { projectConfigSelector, useProjectStore } from "../../stores/project";
 import { Panel } from "./Panel";
-import { TextComponentTab } from "./TextComponentTab";
 
 export const Panels = () => {
-  const panels = [
-    {
-      name: "facs-text",
-      tabs: [
-        {
-          title: "Facsimile",
-          content: <MiradorTab />,
-        },
-        {
-          title: "Text",
-          content: <TextComponentTab />,
-        },
-      ],
-    },
-    {
-      name: "text",
-      tabs: [
-        {
-          title: "Text",
-          content: <TextComponentTab />,
-        },
-      ],
-    },
-  ];
+  const projectConfig = useProjectStore(projectConfigSelector);
   return (
     <>
-      {panels.map((panel, index) => (
-        <Panel key={index} tabsToRender={panel.tabs} name={panel.name} />
+      {projectConfig.panels.map((panel, index) => (
+        <Panel key={index} tabsToRender={panel.tabs} panelName={panel.name} />
       ))}
     </>
   );

--- a/src/components/Detail/Panels.tsx
+++ b/src/components/Detail/Panels.tsx
@@ -8,12 +8,10 @@ export const Panels = () => {
       name: "facs-text",
       tabs: [
         {
-          id: 1,
           title: "Facsimile",
           content: <MiradorTab />,
         },
         {
-          id: 2,
           title: "Text",
           content: <TextComponentTab />,
         },
@@ -23,7 +21,6 @@ export const Panels = () => {
       name: "text",
       tabs: [
         {
-          id: 3,
           title: "Text",
           content: <TextComponentTab />,
         },
@@ -33,7 +30,7 @@ export const Panels = () => {
   return (
     <>
       {panels.map((panel, index) => (
-        <Panel key={index} tabsToRender={panel.tabs} />
+        <Panel key={index} tabsToRender={panel.tabs} name={panel.name} />
       ))}
     </>
   );

--- a/src/components/Detail/TabRecipes.tsx
+++ b/src/components/Detail/TabRecipes.tsx
@@ -1,0 +1,23 @@
+import { MetadataTab } from "./MetadataTab";
+import { MiradorTab } from "./MiradorTab";
+import { TextComponentTab } from "./TextComponentTab";
+import { WebAnnoTab } from "./WebAnnoTab";
+
+export const TabRecipes = {
+  facsTab: {
+    title: "Facsimile",
+    content: <MiradorTab />,
+  },
+  textTab: {
+    title: "Text",
+    content: <TextComponentTab />,
+  },
+  metadataTab: {
+    title: "Metadata",
+    content: <MetadataTab />,
+  },
+  webAnnoTab: {
+    title: "Web annotations",
+    content: <WebAnnoTab />,
+  },
+};

--- a/src/components/Detail/TextComponentTab.tsx
+++ b/src/components/Detail/TextComponentTab.tsx
@@ -1,0 +1,16 @@
+import { projectConfigSelector, useProjectStore } from "../../stores/project";
+import { TextComponent } from "../Text/TextComponent";
+import { useInitDetail } from "./useInitDetail";
+
+export const TextComponentTab = () => {
+  const projectConfig = useProjectStore(projectConfigSelector);
+  const { isLoadingDetail } = useInitDetail();
+
+  return (
+    <TextComponent
+      panelsToRender={projectConfig.defaultTextPanels}
+      allPossiblePanels={projectConfig.allPossibleTextPanels}
+      isLoading={isLoadingDetail}
+    />
+  );
+};

--- a/src/components/Detail/WebAnnoTab.tsx
+++ b/src/components/Detail/WebAnnoTab.tsx
@@ -1,0 +1,28 @@
+import { useAnnotationStore } from "../../stores/annotation";
+import { projectConfigSelector, useProjectStore } from "../../stores/project";
+import { AnnotationFilter } from "../Annotations/AnnotationFilter";
+import { AnnotationItem } from "../Annotations/AnnotationItem";
+
+export const WebAnnoTab = () => {
+  const { annotations } = useAnnotationStore();
+  const projectConfig = useProjectStore(projectConfigSelector);
+
+  return (
+    <>
+      {projectConfig.showWebAnnoTab ? (
+        <>
+          <div className="flex">
+            <AnnotationFilter />
+          </div>
+          {annotations?.length > 0 &&
+            annotations.map((annotation, index) => (
+              <AnnotationItem key={index} annotation={annotation} />
+            ))}
+          {annotations?.length === 0 && (
+            <div className="font-bold">No web annotations</div>
+          )}
+        </>
+      ) : null}
+    </>
+  );
+};

--- a/src/components/Detail/WebAnnoTab.tsx
+++ b/src/components/Detail/WebAnnoTab.tsx
@@ -8,21 +8,21 @@ export const WebAnnoTab = () => {
   const projectConfig = useProjectStore(projectConfigSelector);
 
   return (
-    <>
+    <div className="text-brand1-800 h-full p-5">
       {projectConfig.showWebAnnoTab ? (
         <>
           <div className="flex">
             <AnnotationFilter />
           </div>
-          {annotations?.length > 0 &&
+          {annotations.length > 0 &&
             annotations.map((annotation, index) => (
               <AnnotationItem key={index} annotation={annotation} />
             ))}
-          {annotations?.length === 0 && (
+          {annotations.length === 0 && (
             <div className="font-bold">No web annotations</div>
           )}
         </>
       ) : null}
-    </>
+    </div>
   );
 };

--- a/src/components/Mirador/Mirador.tsx
+++ b/src/components/Mirador/Mirador.tsx
@@ -139,7 +139,7 @@ export function Mirador() {
   return (
     <div
       id="mirador"
-      className="bg-brand1Grey-50 sticky top-0 hidden h-[calc(100vh-100px)] w-7/12 grow self-stretch overflow-auto lg:flex"
+      className="bg-brand1Grey-50 sticky top-0 hidden h-[calc(100vh-137px)] w-full grow self-stretch overflow-auto lg:flex"
     />
   );
 }

--- a/src/components/Text/TextComponent.tsx
+++ b/src/components/Text/TextComponent.tsx
@@ -38,7 +38,7 @@ export const TextComponent = (props: TextComponentProps) => {
   }
 
   return (
-    <div className="flex h-full w-6/12 grow flex-col self-stretch">
+    <div className="flex h-full w-full grow flex-col self-stretch">
       <div className="sr-only">
         <h1>Resolutie</h1>
       </div>

--- a/src/model/ProjectConfig.ts
+++ b/src/model/ProjectConfig.ts
@@ -5,6 +5,7 @@ import {
   AnnoRepoBodyBase,
 } from "./AnnoRepoAnnotation.ts";
 import { Language, LanguageCode } from "./Language.ts";
+import { MiradorConfig } from "./MiradorConfig.ts";
 import {
   GlobaliseSearchResultsBody,
   MondriaanSearchResultsBody,
@@ -15,7 +16,6 @@ import {
   TranslatinSearchResultsBody,
   VanGoghSearchResultsBody,
 } from "./Search.ts";
-import { MiradorConfig } from "./MiradorConfig.ts";
 
 export type ProjectConfig = SearchConfig &
   AnnotationConfig &
@@ -33,6 +33,14 @@ export type ProjectConfig = SearchConfig &
     useExternalConfig: boolean;
     visualizeAnnosMirador: boolean;
     showWebAnnoTab: boolean;
+
+    panels: {
+      name: string;
+      tabs: {
+        title: string;
+        content: JSX.Element;
+      }[];
+    }[];
 
     components: ComponentsConfig;
   };

--- a/src/model/ProjectConfig.ts
+++ b/src/model/ProjectConfig.ts
@@ -34,7 +34,7 @@ export type ProjectConfig = SearchConfig &
     visualizeAnnosMirador: boolean;
     showWebAnnoTab: boolean;
 
-    panels: {
+    detailPanels: {
       name: string;
       tabs: {
         title: string;

--- a/src/projects/default/config/index.tsx
+++ b/src/projects/default/config/index.tsx
@@ -88,5 +88,5 @@ export const defaultConfig: DefaultProjectConfig = {
     showTopMenuButton: false,
   },
   showSearchResultsOnInfoPage: false,
-  panels: [],
+  detailPanels: [],
 };

--- a/src/projects/default/config/index.tsx
+++ b/src/projects/default/config/index.tsx
@@ -88,4 +88,5 @@ export const defaultConfig: DefaultProjectConfig = {
     showTopMenuButton: false,
   },
   showSearchResultsOnInfoPage: false,
+  panels: [],
 };

--- a/src/projects/suriano/config/index.tsx
+++ b/src/projects/suriano/config/index.tsx
@@ -123,7 +123,7 @@ export const surianoConfig: ProjectConfig = merge({}, defaultConfig, {
     sortBy: "date",
     sortOrder: "asc",
   },
-  panels: [
+  detailPanels: [
     {
       name: "facs-text",
       tabs: [TabRecipes.facsTab, TabRecipes.textTab],

--- a/src/projects/suriano/config/index.tsx
+++ b/src/projects/suriano/config/index.tsx
@@ -11,6 +11,8 @@ import "../project.css";
 import { SearchItem } from "../SearchItem";
 import { englishSurianoLabels } from "./englishSurianoLabels";
 
+import { TabRecipes } from "../../../components/Detail/TabRecipes.tsx";
+import { Empty } from "../../../components/Empty.tsx";
 import { EntitySummary } from "../annotation/EntitySummary.tsx";
 import {
   getAnnotationCategory,
@@ -23,13 +25,12 @@ import {
   projectTooltipMarkerAnnotationTypes,
 } from "../annotation/ProjectAnnotationModel.ts";
 import { SearchInfoPage } from "../SearchInfoPage.tsx";
-import { Empty } from "../../../components/Empty.tsx";
 
 export const surianoConfig: ProjectConfig = merge({}, defaultConfig, {
   id: "suriano",
   broccoliUrl: "https://broccoli.suriano.huygens.knaw.nl",
   relativeTo: "tf:File",
-  showWebAnnoTab: false,
+  showWebAnnoTab: true,
   annotationTypesToInclude: [
     // "EntityMetadata",
     // "tei:Author",
@@ -122,4 +123,18 @@ export const surianoConfig: ProjectConfig = merge({}, defaultConfig, {
     sortBy: "date",
     sortOrder: "asc",
   },
+  panels: [
+    {
+      name: "facs-text",
+      tabs: [TabRecipes.facsTab, TabRecipes.textTab],
+    },
+    {
+      name: "text-facs",
+      tabs: [TabRecipes.textTab, TabRecipes.facsTab],
+    },
+    {
+      name: "metadata-webannos",
+      tabs: [TabRecipes.metadataTab, TabRecipes.webAnnoTab],
+    },
+  ],
 } as ProjectSpecificConfig);


### PR DESCRIPTION
Before this PR, only the right side of the detail page was a closable panel with tabs (Metadata and Web annotations). This PR adds closable panels with tabs to the rest of the detail page. The users can now decide for themselves where they want the IIIF viewer or the text component. They can also close the panels they do not wish to use.

This PR is still a work in progress.