### PR TITLE
Fix no search page btn

### DIFF
--- a/src/Detail.tsx
+++ b/src/Detail.tsx
@@ -22,7 +22,7 @@ export const Detail = (props: DetailProps) => {
   );
   const { isInitDetail, isLoadingDetail } = useInitDetail();
 
-  useInitSearch();
+  useInitSearch({ loadDefaultResults: true });
 
   const { searchResults, isInitSearch } = useSearchStore();
 

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -27,7 +27,9 @@ export const Search = () => {
     useUrlSearchParamsStore();
   const { isInitSearch, isLoadingSearch } = useSearchStore();
 
-  useInitSearch();
+  useInitSearch({
+    loadDefaultResults: projectConfig.showSearchResultsOnInfoPage,
+  });
 
   const { getSearchResults } = useSearchResults();
   const {

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -120,6 +120,11 @@ export const Search = () => {
 
   const { isDefaultQuery } = useIsDefaultQuery();
 
+  const isShowingSearchInfoPage =
+    isInitSearch &&
+    isDefaultQuery &&
+    (!searchResults || projectConfig.showSearchResultsOnInfoPage);
+
   return (
     <React.Fragment>
       {isLoading && <SearchLoadingSpinner />}
@@ -135,7 +140,7 @@ export const Search = () => {
         />
         <SearchResultsColumn>
           {/* Wait for init, to prevent a flicker of info page before results are shown: */}
-          {isInitSearch && isDefaultQuery && (
+          {isShowingSearchInfoPage && (
             <projectConfig.components.SearchInfoPage />
           )}
           {isInitSearch && searchResults && (

--- a/src/components/Search/useInitSearch.ts
+++ b/src/components/Search/useInitSearch.ts
@@ -3,13 +3,14 @@ import { handleAbort } from "../../utils/handleAbort.tsx";
 import { useSearchStore } from "../../stores/search/search-store.ts";
 import { isSearchableQuery } from "./isSearchableQuery.ts";
 import { useSearchResults } from "./useSearchResults.tsx";
-import {
-  projectConfigSelector,
-  useProjectStore,
-} from "../../stores/project.ts";
 import { useInitDefaultQuery } from "./useInitDefaultQuery.ts";
 import { useUrlSearchParamsStore } from "./useSearchUrlParamsStore.ts";
 import { useInitSearchUrlParams } from "./useInitSearchUrlParams.tsx";
+import { useIsDefaultQuery } from "./useIsDefaultQuery.ts";
+
+export type UseInitSearchProps = {
+  loadDefaultResults: boolean;
+};
 
 /**
  * Initialize search query, facets and (optional) results
@@ -17,9 +18,7 @@ import { useInitSearchUrlParams } from "./useInitSearchUrlParams.tsx";
  * - fetch keyword and date facets
  * - fetch results when {@link isSearchableQuery}
  */
-export function useInitSearch() {
-  const projectConfig = useProjectStore(projectConfigSelector);
-
+export function useInitSearch(props: UseInitSearchProps) {
   const {
     setSearchResults,
     setKeywordFacets,
@@ -37,6 +36,7 @@ export function useInitSearch() {
 
   useInitDefaultQuery();
   useInitSearchUrlParams();
+  const { isDefaultQuery } = useIsDefaultQuery();
 
   useEffect(() => {
     if (
@@ -61,7 +61,7 @@ export function useInitSearch() {
     setSearchInitStatus({ isLoadingSearch: true });
 
     if (
-      projectConfig.showSearchResultsOnInfoPage ||
+      (props.loadDefaultResults && isDefaultQuery) ||
       isSearchableQuery(searchQuery, defaultQuery)
     ) {
       const searchResults = await getSearchResults(


### PR DESCRIPTION
Fixes two bugs:
- Fix missing search page button when entering detail page without search query
- Hide info page when user forced default query search by pressing enter

Resolves https://github.com/knaw-huc/textannoviz/issues/376