### PR TITLE
Collect and build all tailwind css via project.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,6 @@ cd deploy/dev
 docker compose up
 ```
 
-Open: http://localhost:5183/app/
+Open: http://localhost:5183/
+
+Project can be configured in `docker-dev.sh`.

--- a/scripts/build-project-css.sh
+++ b/scripts/build-project-css.sh
@@ -2,7 +2,6 @@
 set -xe
 
 PROJECTS="brederode globalise hooft israels mondriaan oraties republic suriano translatin vangogh"
-TAILWIND_CSS="src/tailwind.css"
 
 for PROJECT in $PROJECTS; do
   CONFIG="tailwind.config.${PROJECT}.js"
@@ -13,22 +12,21 @@ for PROJECT in $PROJECTS; do
   fi
 
   PROJECT_CSS="src/projects/${PROJECT}/project.css"
-  MERGED_CSS=$(mktemp)
   OUTPUT_CSS="dist/${PROJECT}.css"
 
-  cat "$TAILWIND_CSS" > "$MERGED_CSS"
-  if [ -f "$PROJECT_CSS" ]; then
-    cat "$PROJECT_CSS" >> "$MERGED_CSS"
+  INPUT_CSS=$PROJECT_CSS
+  if [ ! -f "$PROJECT_CSS" ]; then
+    echo "No project.css found for ${PROJECT}"
+    exit 1
   fi
-  echo "Building ${OUTPUT_CSS}"
 
+  echo "Building ${OUTPUT_CSS}"
   npx tailwindcss \
     --config "$CONFIG" \
-    --input "$MERGED_CSS" \
+    --input "$INPUT_CSS" \
     --output "$OUTPUT_CSS" \
     --minify
 
-  rm -f "$MERGED_CSS"
 done
 
 echo "Done building css files for: ${PROJECTS}"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,8 +31,9 @@ const { project, config } = await selectProjectConfig();
  *  - runtime: load the project-specific css file in {@link Layout}
  */
 if (!prodMode) {
-  await import("./tailwind.css");
-  await import(`./projects/${project}/project.css`);
+  await import(`./projects/${project}/project.css`).catch(() =>
+    console.error(`No project.css found for ${project}`),
+  );
 }
 
 const router = await createRouter();

--- a/src/components/Text/Annotated/ProjectAnnotatedText.tsx
+++ b/src/components/Text/Annotated/ProjectAnnotatedText.tsx
@@ -1,6 +1,5 @@
 import { BroccoliTextGeneric } from "../../../model/Broccoli.ts";
 import { useAnnotationStore } from "../../../stores/annotation.ts";
-import "./annotated.css";
 import {
   projectConfigSelector,
   useProjectStore,

--- a/src/components/Text/Annotated/annotated.css
+++ b/src/components/Text/Annotated/annotated.css
@@ -1,7 +1,3 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 .text-button,
 .text-button:active,
 .text-button:focus {

--- a/src/projects/brederode/project.css
+++ b/src/projects/brederode/project.css
@@ -1,0 +1,1 @@
+@import "../../tailwind.css";

--- a/src/projects/globalise/project.css
+++ b/src/projects/globalise/project.css
@@ -1,0 +1,1 @@
+@import "../../tailwind.css";

--- a/src/projects/hooft/project.css
+++ b/src/projects/hooft/project.css
@@ -1,0 +1,1 @@
+@import "../../tailwind.css";

--- a/src/projects/israels/project.css
+++ b/src/projects/israels/project.css
@@ -1,3 +1,5 @@
+@import "../../tailwind.css";
+
 .highlight-italics {
   font-style: italic;
 }

--- a/src/projects/mondriaan/project.css
+++ b/src/projects/mondriaan/project.css
@@ -1,0 +1,1 @@
+@import "../../tailwind.css";

--- a/src/projects/oraties/project.css
+++ b/src/projects/oraties/project.css
@@ -1,3 +1,5 @@
+@import "../../tailwind.css";
+
 /* Marker and highlight styling */
 .marker-head,
 .highlight-head {

--- a/src/projects/republic/project.css
+++ b/src/projects/republic/project.css
@@ -1,3 +1,5 @@
+@import "../../tailwind.css";
+
 /* Republic specific styling for AnnotatedText component */
 
 .annotated-hoe.start-annotation,

--- a/src/projects/suriano/project.css
+++ b/src/projects/suriano/project.css
@@ -1,3 +1,5 @@
+@import "../../tailwind.css";
+
 .highlight-decoded,
 .highlight-displaced {
   font-style: italic;

--- a/src/projects/translatin/project.css
+++ b/src/projects/translatin/project.css
@@ -1,3 +1,5 @@
+@import "../../tailwind.css";
+
 .marker-head {
   font-weight: bold;
 }

--- a/src/projects/vangogh/project.css
+++ b/src/projects/vangogh/project.css
@@ -1,3 +1,5 @@
+@import "../../tailwind.css";
+
 .highlight-italics {
   font-style: italic;
 }

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -1,3 +1,5 @@
+@import "./components/Text/Annotated/annotated.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
This PR fixes annotated.css not being included in the tailwind build of `build-project-css.sh`. All tailwind css is now being collected in project.css using an import of the root tailwind.css. The annotated.css import is now moved from AnnotatedText.tsx to tailwind.css (as should all other css files using tailwind).