### PR TITLE
Persist view/panel settings in browser localstorage

### DIFF
--- a/src/components/Detail/usePanelLayout.tsx
+++ b/src/components/Detail/usePanelLayout.tsx
@@ -37,6 +37,9 @@ export function usePanelLayout(): null {
   const { filterPanels } = projectConfig;
   const activePanels = useDetailViewStore((state) => state.activePanels);
   const setActivePanels = useDetailViewStore((state) => state.setActivePanels);
+  const panelVisibilityPreferences = useDetailViewStore(
+    (state) => state.panelVisibilityPreferences,
+  );
   const annotations = useAnnotationStore((s) => s.annotations);
   const { isLoading, isReady } = useManifest();
 
@@ -65,7 +68,8 @@ export function usePanelLayout(): null {
           ...panel,
           visible:
             filteredByProject.includes(panel.name) &&
-            filteredBySize.includes(panel.name),
+            filteredBySize.includes(panel.name) &&
+            panelVisibilityPreferences[panel.name] !== false,
         })),
       );
     }

--- a/src/components/Detail/usePanelLayout.tsx
+++ b/src/components/Detail/usePanelLayout.tsx
@@ -63,13 +63,22 @@ export function usePanelLayout(): null {
 
       const filteredBySize = isVisibleInLayout(activePanels, windowSize);
 
+      const filteredByPreference = activePanels
+        .filter((p) => {
+          if (p.name in panelVisibilityPreferences) {
+            return panelVisibilityPreferences[p.name];
+          }
+          return true;
+        })
+        .map((p) => p.name);
+
       setActivePanels(
         activePanels.map((panel) => ({
           ...panel,
           visible:
             filteredByProject.includes(panel.name) &&
             filteredBySize.includes(panel.name) &&
-            panelVisibilityPreferences[panel.name] !== false,
+            filteredByPreference.includes(panel.name),
         })),
       );
     }

--- a/src/components/Footer/ViewSettings.tsx
+++ b/src/components/Footer/ViewSettings.tsx
@@ -7,6 +7,9 @@ export const ViewSettings = () => {
   const translateProject = useTranslateProject();
   const activePanels = useDetailViewStore((state) => state.activePanels);
   const setActivePanels = useDetailViewStore((state) => state.setActivePanels);
+  const setPanelVisibilityPreference = useDetailViewStore(
+    (state) => state.setPanelVisibilityPreference,
+  );
   const [isMobileDialogOpen, setIsMobileDialogOpen] = React.useState(false);
   const firstToggleRef = React.useRef<HTMLButtonElement | null>(null);
   const triggerButtonRef = React.useRef<HTMLButtonElement | null>(null);
@@ -30,6 +33,7 @@ export const ViewSettings = () => {
 
       if (activePanel.name === panelName) {
         activePanel.visible = !activePanel.visible;
+        setPanelVisibilityPreference(panelName, activePanel.visible);
         return activePanel;
       }
 

--- a/src/stores/detail-view/detail-view-store.ts
+++ b/src/stores/detail-view/detail-view-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
 import {
   ActiveSidebarTabSlice,
   createActiveSidebarTabSlice,
@@ -7,10 +8,26 @@ import {
   ActivePanelsSlice,
   createActivePanelsSlice,
 } from "./activePanelsSlice";
+import {
+  PanelVisibilityPreferencesSlice,
+  createPanelVisibilityPreferencesSlice,
+} from "./panelVisibilityPreferencesSlice";
 
 export const useDetailViewStore = create<
-  ActiveSidebarTabSlice & ActivePanelsSlice
->()((...a) => ({
-  ...createActiveSidebarTabSlice(...a),
-  ...createActivePanelsSlice(...a),
-}));
+  ActiveSidebarTabSlice & ActivePanelsSlice & PanelVisibilityPreferencesSlice
+>()(
+  persist(
+    (...a) => ({
+      ...createActiveSidebarTabSlice(...a),
+      ...createActivePanelsSlice(...a),
+      ...createPanelVisibilityPreferencesSlice(...a),
+    }),
+    {
+      name: "detail-view-store",
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        panelVisibilityPreferences: state.panelVisibilityPreferences,
+      }),
+    },
+  ),
+);

--- a/src/stores/detail-view/panelVisibilityPreferencesSlice.ts
+++ b/src/stores/detail-view/panelVisibilityPreferencesSlice.ts
@@ -1,0 +1,22 @@
+import { StateCreator } from "zustand";
+
+export type PanelVisibilityPreferencesSlice = {
+  panelVisibilityPreferences: Record<string, boolean>;
+  setPanelVisibilityPreference: (name: string, visible: boolean) => void;
+};
+
+export const createPanelVisibilityPreferencesSlice: StateCreator<
+  PanelVisibilityPreferencesSlice,
+  [],
+  [],
+  PanelVisibilityPreferencesSlice
+> = (set) => ({
+  panelVisibilityPreferences: {},
+  setPanelVisibilityPreference: (name, visible) =>
+    set((state) => ({
+      panelVisibilityPreferences: {
+        ...state.panelVisibilityPreferences,
+        [name]: visible,
+      },
+    })),
+});


### PR DESCRIPTION
This PR adds a Zustand slice containing the panels the user has active. This slice is saved to the browser's local storage.

Now, the user can deselect the 'Facsimile' panel, and that panel will stay hidden when they browse to the next letter, perform a new search, or close TAV and reopen it the next day. Window resize changes are not saved.

Resolves #411.